### PR TITLE
[C++] Update C++ Docs URL slug from cxx to cpp

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -7,4 +7,4 @@ symlink: current -> master
 raw: ${prefix}/ -> ${base}/current/
 raw: ${prefix}/stable -> ${base}/current/
 raw: ${prefix}/master -> ${base}/upcoming/
-
+raw: /docs/languages/cxx -> /docs/languages/cpp

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,4 +1,4 @@
-name = "cpp"
+name = "cpp-driver"
 title = "C++ Driver"
 
 intersphinx = [

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,4 +1,4 @@
-name = "cpp-driver"
+name = "cpp"
 title = "C++ Driver"
 
 intersphinx = [


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-36132>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/cpp-driver/docsworker-xlarge/DOCSP-36132/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?