### PR TITLE
Remove recommendation against including unqualified unstable ABI headers 

### DIFF
--- a/source/api-abi-versioning.txt
+++ b/source/api-abi-versioning.txt
@@ -54,12 +54,12 @@ The public header files of the bsoncxx library are organized by ABI namespace:
 
 For forward compatibility, a public header file in an ABI namespace directory ``vA`` may include a header file in a *newer* ABI namespace directory ``vB``, where ``A < B``.
 Such forward compatibility include directives, when supported, will be explicitly documented.
-For any given public API entity, we recommend including its corresponding header
-from the *latest* ABI namespace directory whenever available.
+When ABI stability is required, we recommend including headers from the *latest* stable ABI namespace directory.
+If ABI stability is not required, we recommend including the appropriate *unstable* ABI header instead.
 
 .. important::
 
-   For backward compatibility, the ``bsoncxx/v_noabi/`` ABI namespace directory is added to include paths such that ``#include <bsoncxx/example.hpp>`` is equivalent to ``#include <bsoncxx/v_noabi/bsoncxx/example.hpp>``. Relying on this behavior is discouraged: we recommend explicitly including ``#include <bsoncxx/v_noabi/bsoncxx/example.hpp>`` instead.
+   The ``bsoncxx/v_noabi/`` unstable ABI namespace directory is prioritized before the ``bsoncxx/`` root directory in include paths, such that ``#include <bsoncxx/example.hpp>`` is equivalent to ``#include <bsoncxx/v_noabi/bsoncxx/example.hpp>``.
 
 .. note::
 


### PR DESCRIPTION
JIRA - https://jira.mongodb.org/browse/DOCSP-44061
The original wording assumed an eventual deprecate-and-remove plan for the `bsoncxx/v_noabi/` include path. This is no longer the case: `<bsoncxx/example.hpp>` will continue to be supported as the recommended means of including unstable ABI headers.