### PR TITLE
(DOCSP-39838) [CPP Driver] Write Data to MongoDB > Replace a Document

### DIFF
--- a/source/includes/usage-examples/write-code-examples.cpp
+++ b/source/includes/usage-examples/write-code-examples.cpp
@@ -60,7 +60,10 @@ int main() {
     {
 
         // start-replace-one
+        auto query_filter = make_document(kvp("<field to match>", "<value to match>"));
+        auto update_doc = make_document(make_document(kvp("<field name>", "<value>")));
 
+        auto result = collection.update_many(query_filter.view(), update_doc.view());
         // end-replace-one 
     }
 

--- a/source/includes/usage-examples/write-code-examples.cpp
+++ b/source/includes/usage-examples/write-code-examples.cpp
@@ -61,9 +61,9 @@ int main() {
         // Replaces a document that matches the specified criteria
         // start-replace-one
         auto query_filter = make_document(kvp("<field to match>", "<value to match>"));
-        auto update_doc = make_document(make_document(kvp("<field name>", "<value>")));
+        auto replace_doc = make_document(make_document(kvp("<field name>", "<value>")));
 
-        auto result = collection.replace_one(query_filter.view(), update_doc.view());
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view());
         // end-replace-one 
     }
 

--- a/source/includes/usage-examples/write-code-examples.cpp
+++ b/source/includes/usage-examples/write-code-examples.cpp
@@ -58,6 +58,13 @@ int main() {
     }
 
     {
+
+        // start-replace-one
+
+        // end-replace-one 
+    }
+
+    {
         // Deletes a document that matches the specified criteria
         // start-delete-one
         auto result = collection.delete_one(make_document(kvp("<field name>", "<value>")));

--- a/source/includes/usage-examples/write-code-examples.cpp
+++ b/source/includes/usage-examples/write-code-examples.cpp
@@ -58,7 +58,7 @@ int main() {
     }
 
     {
-
+        // Replaces a document that matches the specified criteria
         // start-replace-one
         auto query_filter = make_document(kvp("<field to match>", "<value to match>"));
         auto update_doc = make_document(make_document(kvp("<field name>", "<value>")));

--- a/source/includes/usage-examples/write-code-examples.cpp
+++ b/source/includes/usage-examples/write-code-examples.cpp
@@ -63,7 +63,7 @@ int main() {
         auto query_filter = make_document(kvp("<field to match>", "<value to match>"));
         auto update_doc = make_document(make_document(kvp("<field name>", "<value>")));
 
-        auto result = collection.update_many(query_filter.view(), update_doc.view());
+        auto result = collection.replace_one(query_filter.view(), update_doc.view());
         // end-replace-one 
     }
 

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -33,6 +33,10 @@ int main() {
 
         // start-replace-options
 
+        auto query_filter = make_document(kvp("name", "Bagels N Buns"));
+        auto replace_doc = make_document(kvp("name", "2 Bagels 2 Buns"));
+
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view());
             // - bypass_document_validation ()
             // - collation () 
             // - upsert ()

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -23,17 +23,20 @@ int main() {
         // replaces the fields and values of a document with the name "Bagels N Buns" with a document 
         // with the same _id value and no fields other than the name "2 Bagels 2 Buns"
         // start-replace-one
-        // Create inputs 
         auto query_filter = make_document(kvp("name", "Nobu"));
         auto replace_doc = make_document(kvp("name", "La Bernadin"));
 
-        // Call replace_one()
         auto result = collection.replace_one(query_filter.view(), replace_doc.view());
+        // end-replace-one
+    }
 
-        // Print new document 
+    {
+        // replaces the fields and values of a document with the name "Bagels N Buns" with a document 
+        // with the same _id value and no fields other than the name "2 Bagels 2 Buns"
+        // start-replace-one-iox
         auto new_doc = collection.find_one(make_document(kvp("name", "La Bernadin")));
         std::cout << "New document: " << bsoncxx::to_json(*new_doc) << std::endl;
-        // end-replace-one
+        // end-replace-one-io
     }
 
     {

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -69,13 +69,30 @@ int main() {
     {
 
         // Replaces the matching document and prints the number of modified documents
-        // start-replace-result
-        auto query_filter = make_document(kvp("name", "Nobu"));
-        auto replace_doc = make_document(kvp("name", "La Bernadin'"));
+        // start-replace-result-matched
+        auto query_filter = make_document(kvp("name", "Shake Shack"));
+        auto replace_doc = make_document(kvp("name", "In-N-Out Burger"));
 
         auto result = collection.replace_one(query_filter.view(), replace_doc.view());
-        std::cout << "Modified documents: " << result->modified_count() << std::endl;
         std::cout << "Matched documents: " << result->matched_count() << std::endl;        
-        // end-replace-result
+        std::cout << "Modified documents: " << result->modified_count() << std::endl;
+        // end-replace-result-matched
+    }
+
+    {
+
+        // Replaces the matching document and prints the number of modified documents
+        // start-replace-result-upsert
+        mongocxx::options::replace opts; 
+        opts.upsert(true);
+
+        auto query_filter = make_document(kvp("name", "In-N-Out Burger"));
+        auto replace_doc = make_document(kvp("name", "Shake Shack"));
+
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view(), opts);
+        auto id = result->upserted_id()->get_value();
+                
+        std::cout << "Upserted ID: " << id.get_oid().value.to_string() << std::endl;
+            // end-replace-result-upsert
     }
 }

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -23,11 +23,14 @@ int main() {
         // replaces the fields and values of a document with the name "Bagels N Buns" with a document 
         // with the same _id value and no fields other than the name "2 Bagels 2 Buns"
         // start-replace-one
+        // Create inputs 
         auto query_filter = make_document(kvp("name", "Nobu"));
         auto replace_doc = make_document(kvp("name", "La Bernadin"));
 
+        // Call replace_one()
         auto result = collection.replace_one(query_filter.view(), replace_doc.view());
 
+        // Print new document 
         auto new_doc = collection.find_one(make_document(kvp("name", "La Bernadin")));
         std::cout << "New document: " << bsoncxx::to_json(*new_doc) << std::endl;
         // end-replace-one

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -31,8 +31,7 @@ int main() {
     }
 
     {
-        // replaces the fields and values of a document with the name "Bagels N Buns" with a document 
-        // with the same _id value and no fields other than the name "2 Bagels 2 Buns"
+        // Print replace_one() output
         // start-replace-one-iox
         auto new_doc = collection.find_one(make_document(kvp("name", "La Bernadin")));
         std::cout << "New document: " << bsoncxx::to_json(*new_doc) << std::endl;

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -38,7 +38,7 @@ int main() {
         auto index_specification = make_document(kvp("name", 1));
         collection.create_index(index_specification.view());
 
-        mongocxx::options::replace opts; 
+        mongocxx::options::replace opts{}; 
         opts.hint(mongocxx::hint{"name_1"});
 
         auto query_filter = make_document(kvp("name", "Nobu"));
@@ -50,7 +50,7 @@ int main() {
     
     {
         // start-replace-options-upsert
-        mongocxx::options::replace opts; 
+        mongocxx::options::replace opts{}; 
         opts.upsert(true);
 
         auto query_filter = make_document(kvp("name", "In-N-Out Burger"));
@@ -77,7 +77,7 @@ int main() {
 
         // Replaces the matching document and prints the number of modified documents
         // start-replace-result-upsert
-        mongocxx::options::replace opts; 
+        mongocxx::options::replace opts{}; 
         opts.upsert(true);
 
         auto query_filter = make_document(kvp("name", "In-N-Out Burger"));

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -29,17 +29,28 @@ int main() {
         auto result = collection.replace_one(query_filter.view(), replace_doc.view());
         // end-replace-one
     }
+
+    // 
+    {
+        // start-replace-options-upsert
+        std::cout << "Number of documents before replace: " << collection.count_documents({}) << std::endl;
+
+        mongocxx::options::replace opts; 
+        opts.upsert(true);
+
+        auto query_filter = make_document(kvp("name", "In-N-Out Burger"));
+        auto replace_doc = make_document(kvp("name", "Shake Shack"));
+
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view(), opts);
+        std::cout << "Number of documents after replace: " << collection.count_documents({}) << std::endl;
+        // end-replace-options-upsert
+    }
+
     {
 
-        // start-replace-options
+        // start-replace-options-validation
 
-            // - bypass_document_validation ()
-            // - collation () 
-            // - upsert ()
-            // - write concern ()
-            // more: https://mongocxx.org/api/current/classmongocxx_1_1v__noabi_1_1options_1_1replace.html
-
-        // end-replace-options
+        // end-replace-options-validation
     }
     {
 

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -23,33 +23,14 @@ int main() {
         // replaces the fields and values of a document with the name "Bagels N Buns" with a document 
         // with the same _id value and no fields other than the name "2 Bagels 2 Buns"
         // start-replace-one
-        auto query_filter = make_document(kvp("name", "Bagels N Buns"));
-        auto replace_doc = make_document(kvp("name", "2 Bagels 2 Buns"));
+        auto query_filter = make_document(kvp("name", "Nobu"));
+        auto replace_doc = make_document(kvp("name", "La Bernadin"));
 
         auto result = collection.replace_one(query_filter.view(), replace_doc.view());
+
+        auto new_doc = collection.find_one(make_document(kvp("name", "La Bernadin")));
+        std::cout << "New document: " << bsoncxx::to_json(*new_doc) << std::endl;
         // end-replace-one
-    }
-
-    // 
-    {
-        // start-replace-options-upsert
-        std::cout << "Number of documents before replace: " << collection.count_documents({}) << std::endl;
-
-        mongocxx::options::replace opts; 
-        opts.upsert(true);
-
-        auto query_filter = make_document(kvp("name", "In-N-Out Burger"));
-        auto replace_doc = make_document(kvp("name", "Shake Shack"));
-
-        auto result = collection.replace_one(query_filter.view(), replace_doc.view(), opts);
-        std::cout << "Number of documents after replace: " << collection.count_documents({}) << std::endl;
-        // end-replace-options-upsert
-    }
-
-    {
-        // start-replace-options-validation
-
-        // end-replace-options-validation
     }
 
     {
@@ -66,16 +47,29 @@ int main() {
         auto result = collection.replace_one(query_filter.view(), replace_doc.view(), opts);
         // end-replace-options-hint 
     }
+    
     {
+        // start-replace-options-upsert
+        mongocxx::options::replace opts; 
+        opts.upsert(true);
 
-        // Replaces the matching document and prints the number of modified documents
+        auto query_filter = make_document(kvp("name", "In-N-Out Burger"));
+        auto replace_doc = make_document(kvp("name", "Shake Shack"));
+
+        std::cout << "Number of documents before replace: " << collection.count_documents({}) << std::endl;
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view(), opts);
+        std::cout << "Number of documents after replace: " << collection.count_documents({}) << std::endl;
+        // end-replace-options-upsert
+    }
+
+    {
+        // Replaces the matching document and prints the number of matched documents
         // start-replace-result-matched
         auto query_filter = make_document(kvp("name", "Shake Shack"));
         auto replace_doc = make_document(kvp("name", "In-N-Out Burger"));
 
         auto result = collection.replace_one(query_filter.view(), replace_doc.view());
         std::cout << "Matched documents: " << result->matched_count() << std::endl;        
-        std::cout << "Modified documents: " << result->modified_count() << std::endl;
         // end-replace-result-matched
     }
 
@@ -93,6 +87,6 @@ int main() {
         auto id = result->upserted_id()->get_value();
                 
         std::cout << "Upserted ID: " << id.get_oid().value.to_string() << std::endl;
-            // end-replace-result-upsert
+        // end-replace-result-upsert
     }
 }

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -20,8 +20,8 @@ int main() {
     // end-db-coll
 
     {
-        // replaces the fields and values of a document with the name "Bagels N Buns" with a document 
-        // with the same _id value and no fields other than the name "2 Bagels 2 Buns"
+        // replaces a document that has a "name" value of "Nobu"
+        // with a document that has a "name" of "La Bernadin"
         // start-replace-one
         auto query_filter = make_document(kvp("name", "Nobu"));
         auto replace_doc = make_document(kvp("name", "La Bernadin"));
@@ -31,7 +31,7 @@ int main() {
     }
 
     {
-        // Print replace_one() output
+        // Retrieves a document to verify the replacement operation
         // start-replace-one-io
         auto new_doc = collection.find_one(make_document(kvp("name", "La Bernadin")));
         std::cout << "New document: " << bsoncxx::to_json(*new_doc) << std::endl;
@@ -54,6 +54,7 @@ int main() {
     }
     
     {
+        // Replaces a document that has a "name" value of "Nobu" and instructs the operation to use the "name_1" field index
         // start-replace-options-upsert
         std::cout << "Total document count before replace_one(): " << collection.count_documents({}) << std::endl;
 
@@ -82,7 +83,8 @@ int main() {
 
     {
 
-        // Replaces the matching document and prints the number of modified documents
+        // Replaces a document that has a "name" value of "In-N-Out Burger" and instructs the operation
+        // to insert a new document if none match.
         // start-replace-result-upsert
         mongocxx::options::replace opts{}; 
         opts.upsert(true);

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -47,10 +47,24 @@ int main() {
     }
 
     {
-
         // start-replace-options-validation
 
         // end-replace-options-validation
+    }
+
+    {
+        // start-replace-options-hint
+        auto index_specification = make_document(kvp("name", 1));
+        collection.create_index(index_specification.view());
+
+        mongocxx::options::replace opts; 
+        opts.hint(mongocxx::hint{"name_1"});
+
+        auto query_filter = make_document(kvp("name", "Nobu"));
+        auto replace_doc = make_document(kvp("name", "La Bernadin"));
+
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view(), opts);
+        // end-replace-options-hint 
     }
     {
 

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -32,7 +32,7 @@ int main() {
 
     {
         // Print replace_one() output
-        // start-replace-one-iox
+        // start-replace-one-io
         auto new_doc = collection.find_one(make_document(kvp("name", "La Bernadin")));
         std::cout << "New document: " << bsoncxx::to_json(*new_doc) << std::endl;
         // end-replace-one-io

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -70,8 +70,8 @@ int main() {
 
         // Replaces the matching document and prints the number of modified documents
         // start-replace-result
-        auto query_filter = make_document(kvp("name", "Dunkin' Donuts"));
-        auto replace_doc = make_document(kvp("name", "Dunkin'"));
+        auto query_filter = make_document(kvp("name", "Nobu"));
+        auto replace_doc = make_document(kvp("name", "La Bernadin'"));
 
         auto result = collection.replace_one(query_filter.view(), replace_doc.view());
         std::cout << "Modified documents: " << result->modified_count() << std::endl;

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -54,7 +54,7 @@ int main() {
     }
     
     {
-        // Replaces a document that has a "name" value of "Nobu" and instructs the operation to use the "name_1" field index
+        // Replaces a document that has a "name" value of "Nobu" and instructs the operation to use the "name" field index
         // start-replace-options-upsert
         std::cout << "Total document count before replace_one(): " << collection.count_documents({}) << std::endl;
 

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -39,6 +39,7 @@ int main() {
     }
 
     {
+        // Replaces a document that has a "name" value of "Nobu" and instructs the operation to use the "name" field index
         // start-replace-options-hint
         auto index_specification = make_document(kvp("name", 1));
         collection.create_index(index_specification.view());
@@ -54,7 +55,8 @@ int main() {
     }
     
     {
-        // Replaces a document that has a "name" value of "Nobu" and instructs the operation to use the "name" field index
+        // Replaces a document that has a "name" value of "In-N-Out Burger" 
+        // and instructs the operation to insert a new operation if none match.
         // start-replace-options-upsert
         std::cout << "Total document count before replace_one(): " << collection.count_documents({}) << std::endl;
 

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/json.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+using bsoncxx::builder::basic::kvp;
+using bsoncxx::builder::basic::make_document;
+
+int main() {
+    mongocxx::instance instance;
+    mongocxx::uri uri("<connection string>");
+    mongocxx::client client(uri);
+
+    // start-db-coll
+    auto db = client["sample_restaurants"];
+    auto collection = db["restaurants"];
+    // end-db-coll
+
+    {
+        // replaces the fields and values of a document with the name "Bagels N Buns" with a document 
+        // with the same _id value and no fields other than the name "2 Bagels 2 Buns"
+        // start-replace-one
+        auto query_filter = make_document(kvp("name", "Bagels N Buns"));
+        auto replace_doc = make_document(kvp("name", "2 Bagels 2 Buns"));
+
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view());
+        // end-replace-one
+    }
+    {
+
+        // start-replace-options
+
+            // - bypass_document_validation ()
+            // - collation () 
+            // - upsert ()
+            // - write concern ()
+            // more: https://mongocxx.org/api/current/classmongocxx_1_1v__noabi_1_1options_1_1replace.html
+
+        // end-replace-options
+    }
+    {
+
+        // Replaces the matching document and prints the number of modified documents
+        // start-replace-result
+        auto query_filter = make_document(kvp("name", "Dunkin' Donuts"));
+        auto replace_doc = make_document(kvp("name", "Dunkin'"));
+
+        auto result = collection.replace_one(query_filter.view(), replace_doc.view());
+        std::cout << "Modified documents: " << result->modified_count() << std::endl;
+        std::cout << "Matched documents: " << result->matched_count() << std::endl;        
+        // end-replace-result
+    }
+}

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -55,15 +55,17 @@ int main() {
     
     {
         // start-replace-options-upsert
+        std::cout << "Total document count before replace_one(): " << collection.count_documents({}) << std::endl;
+
         mongocxx::options::replace opts{}; 
         opts.upsert(true);
 
         auto query_filter = make_document(kvp("name", "In-N-Out Burger"));
         auto replace_doc = make_document(kvp("name", "Shake Shack"));
 
-        std::cout << "Number of documents before replace: " << collection.count_documents({}) << std::endl;
         auto result = collection.replace_one(query_filter.view(), replace_doc.view(), opts);
-        std::cout << "Number of documents after replace: " << collection.count_documents({}) << std::endl;
+        
+        std::cout << "Total document count after replace_one(): " << collection.count_documents({}) << std::endl;
         // end-replace-options-upsert
     }
 

--- a/source/includes/write/replace.cpp
+++ b/source/includes/write/replace.cpp
@@ -33,10 +33,6 @@ int main() {
 
         // start-replace-options
 
-        auto query_filter = make_document(kvp("name", "Bagels N Buns"));
-        auto replace_doc = make_document(kvp("name", "2 Bagels 2 Buns"));
-
-        auto result = collection.replace_one(query_filter.view(), replace_doc.view());
             // - bypass_document_validation ()
             // - collation () 
             // - upsert ()

--- a/source/write.txt
+++ b/source/write.txt
@@ -24,6 +24,7 @@ Write Data to MongoDB
 
    /write/insert
    /write/update
+   /write/replace 
    /write/delete
    /write/bulk-write
 
@@ -115,9 +116,19 @@ or editing a field:
 To learn more about the ``update_many()`` method, see the
 :ref:`Update Documents <cpp-write-update>` guide.
 
-.. TODO:
- Replace One
- -----------
+Replace One
+-----------
+
+The following code shows how to replace a single document in a collection: 
+
+.. literalinclude:: /includes/usage-examples/write-code-examples.cpp
+   :start-after: start-replace-one
+   :end-before: end-replace-one
+   :language: cpp
+   :dedent:
+
+To learn more about the ``replace_one()`` method, see the 
+:ref:`Replace Documents <cpp-write-replace>` guide. 
 
 Delete One
 ----------

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -174,11 +174,10 @@ To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexe
 Example: upsert 
 ^^^^^^^^^^^^^^^^^^^
 
-The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
-and sets its ``upsert`` field value to ``true``.  When ``opts`` is passed in as an optional argument, the ``replace_one()`` method
-searches the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``"In-N-Out Burger"``. 
-Because this sample collection does not contain a document matching this query filter,
-the ``replace_one()`` method upserts a new document with a ``name`` field value of ``"Shake Shack"`` into the collection. 
+The following example passes a ``mongocxx::options::replace`` object to the ``replace_one()`` method 
+after setting its ``upsert`` field value to ``true``.  
+Because no documents match the query filter, this instructs the replace operation to insert a new document
+with a ``name`` field value of ``"Shake Shack"`` into the collection:
 
 .. io-code-block::
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -1,8 +1,8 @@
 .. _cpp-write-replace:
 
-================
+=================
 Replace Documents
-================
+=================
 
 .. contents:: On this page
    :local:
@@ -58,7 +58,7 @@ Each replace method requires the following parameters:
 - **Replace** document: Specifies the fields and values to insert in the new document. 
 
 Replace One Document
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 The following example uses the ``replace_one()`` method to replace the fields and values
 of a document in which the ``name`` field value is ``Bagels N Buns``:
@@ -71,7 +71,7 @@ of a document in which the ``name`` field value is ``Bagels N Buns``:
 
 
 Customize the Replace Operation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can modify the behavior of the ``replace_one()`` method by
 passing an instance of the ``mongocxx::options::replace`` class as an optional
@@ -96,7 +96,7 @@ instance of the class using the dot operator ``(.)``.
 
    * - ``collation(<document::view_or_value collation>)``
      - | Specifies the kind of language collation to use when sorting
-         results. Accepts a `collation document </reference/collation/#collation-document>` as its argument.
+         results. Accepts a :manual:`collation document </reference/collation/#collation-document>` as its argument.
        | For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
          in the {+mdb-server+} manual.
 
@@ -143,12 +143,6 @@ the {+driver-short+} inserts a new document into the collection rather than repl
    :language: cpp
    :dedent:
 
-.. The following example uses the ``replace_one()`` method to search for a *Query-Filter* document 
-.. with the ``name`` field value of ``Nobu`` and replace it with a *Replace* document with the
-.. ``name`` field value of ``La Bernadin``. To find the *Query-Filter* document 
-.. The following example uses the ``hint`` option to search for a *Query-Filter* document 
-.. with a ``name`` field value indexed in an ascending single-field index. 
-
 
 The following code shows how to use the ``hint`` option to optimize the query performance of the ``replace_one()`` method:
 
@@ -158,14 +152,10 @@ The following code shows how to use the ``hint`` option to optimize the query pe
    :language: cpp
    :dedent:
 
-The above example uses `create_index() <cpp-indexes>` to create an ascending single-field index using the ``name`` field. 
+The above example uses :ref:`create_index() <cpp-indexes>` to create an ascending single-field index using the ``name`` field. 
 The name of this index, ``name_1``, is then passed as an argument to the ``hint`` member function of ``opts``, an instance of the 
 ``mongocxx::options::replace`` class. ``opts`` is then passed as the third argument to the ``replace_one()`` function, which replaces
  a document with a ``name`` field value of ``Nobu` with a new document with a ``name`` field value of ``La Bernadin``.
-
-.. to optimize the search for a *Query-Filter* document with a ``name`` field value of ``Nobu``. When this document 
-.. is found, it is replaced by a new document with a ``name`` field value of ``La Bernadin``. 
-.. created using the ``name`` field. 
 
 Return Value
 ~~~~~~~~~~~~

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -69,17 +69,28 @@ The following example uses the ``replace_one()`` method to replace
 a document that has a ``name`` field value of ``Nobu`` with a new document 
 that has a ``name`` field value of ``La Bernadin``:
 
+.. literalinclude:: /includes/write/replace.cpp
+   :start-after: start-replace-one
+   :end-before: end-replace-one
+   :language: cpp
+   :dedent:
+
+To check if you successfully created the collection, you can print out a list of all collections in the database:
+
 .. io-code-block::
 
    .. input:: /includes/write/replace.cpp
-      :start-after: start-replace-one
-      :end-before: end-replace-one
+      :start-after: start-replace-one-io
+      :end-before: end-replace-one-io
       :language: cpp
       :dedent:
    
    .. output:: 
+      :language: cli
+      :visible: false
       
-      New document: { "_id" : { "$oid" : "5eb3d668b31de5d588f42e34" }, "name" : "La Bernadin" }
+      New document: { "_id" : { "$oid" : "5eb3d668b31de5d588f42e34" }, "name" : "La Bernadin" }  
+
 
 Options 
 ~~~~~~~
@@ -111,12 +122,12 @@ argument. The following table describes the fields you can set in a
          Once set, this comment appears alongside records of this command in the following locations:
 
         - :ref:`mongod log messages <log-messages-ref>`, in the
-          ``attr.command.cursor.comment`` field.
+          ``attr.command.cursor.comment`` field
         - :ref:`Database profiler <profiler>` output, in the :data:`command.comment
-          <system.profile.command>` field.
+          <system.profile.command>` field
         - :dbcommand:`currentOp` output, in the :data:`command.comment
-        <currentOp.command>` field.
-        
+          <currentOp.command>` field
+
        | For more information, see the :manual:`insert Command
          Fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -105,7 +105,7 @@ argument. The following table describes the fields you can set in a
    :widths: 30 70
    :header-rows: 1
 
-   * - Function 
+   * - Field 
      - Description
 
    * - ``bypass_document_validation``
@@ -206,7 +206,7 @@ member functions:
    :widths: 30 70
    :header-rows: 1
 
-   * - Field
+   * - Function
      - Description
 
    * - ``matched_count()``

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -122,10 +122,9 @@ argument. The following table describes the fields you can set in a
 
         - :ref:`mongod log messages <log-messages-ref>`, in the
           ``attr.command.cursor.comment`` field
-        - :ref:`Database profiler <profiler>` output, in the :data:`command.comment
-          <system.profile.command>` field
-        - :dbcommand:`currentOp` output, in the :data:`command.comment
-          <currentOp.command>` field
+        - :ref:`Database profiler output <profiler>`, in the :data:`system.profile.command <system.profile.command>` ``comment`` field
+        - :dbcommand:`currentOp` output, in the :data:`currentOp.command
+          <currentOp.command>` ``comment`` field
 
        | For more information, see the :manual:`insert Command
          Fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -265,6 +265,7 @@ Then, the code calls the ``upserted_id()`` member function to print the ``_id`` 
       :language: cli
       :visible: false
 
+      // Your ID value may differ
       Upserted ID: 67128c5ecc1f8c15ea26fcf8
 
 Additional Information 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -227,10 +227,10 @@ member functions:
 Example: ``matched_count()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following example uses the ``replace_one()`` to replace a document that has
+The following example uses the ``replace_one()`` method to replace a document that has
 a ``name`` field value of ``Shake Shack`` with a new document that has a ``name`` 
-field value of ``In-N-Out Burger``. It calls the ``matched_count()`` member 
-function to print the number of matched documents:
+field value of ``In-N-Out Burger``. It then calls the ``matched_count()`` member 
+function to print the number of documents that match the search for a ``name`` field value of ``Shake Shack``:
 
 .. io-code-block::
 
@@ -249,7 +249,7 @@ Example: ``upserted_id()``
 
 The following example uses the ``replace_one()`` method to find and replace a document with a ``name`` field value of ``In-N-Out Burger``. 
 Because the upsert option is set to true, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
-Then, the ``upserted_id()`` member function is called to print the ``_id`` field value of the upserted document. 
+It then cals the ``upserted_id()`` member function to print the ``_id`` field value of the upserted document. 
 
 .. io-code-block::
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -85,11 +85,9 @@ parameter. This class contains the following member functions:
      - Description
 
    * - ``bypass_document_validation(<bool bypass_document_validation>)``
-     - | Specifies whether the replace operation bypasses document validation. When set to ``true``,
-         this lets you replace a document with a new document that doesn't meet the schema validation requirements. 
-         For more information about schema validation, see :manual:`Schema
-         Validation </core/schema-validation/#schema-validation>` in the MongoDB
-         Server manual.
+     - | Specifies whether the replace operation bypasses document validation. Accepts a boolean value as its argument. 
+       | When set to ``true``, this lets you replace a document with a new document that doesn't meet the schema validation requirements. 
+       | For more information, see :manual:`Schema Validation </core/schema-validation/#schema-validation>` in the {+mdb-server+} manual.
        | Defaults to ``false``.
 
    * - ``collation(<document::view_or_value collation>)``
@@ -99,10 +97,14 @@ parameter. This class contains the following member functions:
          in the {+mdb-server+} manual.
 
    * - ``comment(<bson_value::view_or_value comment>)``
-     - | Specifies a comment to attach to the operation. Accepts a comment of any BSON type as its argument.
+     - | Specifies a comment to attach to the operation. Accepts a comment of any valid BSON type as its argument (string, integer, object, array, etc).
+       | Once set, this comment appears alongside records of this command in the following locations:
+         - mongod log messages, in the attr.command.cursor.comment field.
+         - Database profiler output, in the command.comment field.
+         - currentOp output, in the command.comment field. 
        | For more information, see the :manual:`insert command
          fields </reference/command/insert/#command-fields>` guide in the
-         {+mdb-server+} manual for more information.
+         {+mdb-server+} manual. 
 
    * - ``hint``
      - | Specifies the index to search for the **Query Filter** document. Accepts an instance of the mongocxx::v_noabi::hint class representing an
@@ -111,30 +113,32 @@ parameter. This class contains the following member functions:
          in the {+mdb-server+} manual.
 
    * - ``let``
-     - | Specifies a document with a list of values to improve operation readability.
-         Values must be constant or closed expressions that don't reference document
-         fields. For more information, see the :manual:`let statement
-         </reference/command/replace/#std-label-replace-let-syntax>` in the
+     - | Specifies variables and their values to be used in the ``replace_one()`` method. 
+         Accepts a document containing variable-value pairs. To access the value of a variable in the method, 
+         use the double dollar sign prefix ($$) together with your variable name in the form ``$$<variable-name>``. 
+       | This allows you to improve command readability by separating 
+         the variables from the query text.
+       | For more information, see :manual:`let 
+         </reference/command/update/#std-label-replace-let-syntax>` in the
          {+mdb-server+} manual.
 
    * - ``upsert``
      - | Specifies whether the replace operation performs an upsert operation if no 
-         documents match the query filter. For more information, see the :manual:`upsert
-         statement </reference/command/replace/#std-label-replace-command-upsert>`
-         in the {+mdb-server+} manual.
+         documents match the query filter. Accepts a boolean value as its argument. 
        | Defaults to ``false``.
 
    * - ``write_concern``
      - | Sets the write concern for the operation.
-         For more information, see :manual:`Write Concern </reference/write-concern/>`
+       | For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
 
 Examples 
 ^^^^^^^^
-.. example:: 
-The following code uses the ``upsert`` option set to ``true`` in order to insert a new document with a ``name``
-value of ``Shake Shack`` if its search for a *Query Filter* document with a ``name`` value of ``In-N-Out Burger`` 
-does not match any existing documents. 
+
+The following code uses the ``replace_one()`` function with an ``upsert`` option set to ``true``
+to insert a new document with a ``name`` value of ``Shake Shack`` into the ``sample_restaurants.restaurants`` collection 
+when its search for a document with a ``name`` value of ``In-N-Out Burger`` 
+does not match an existing document: 
  
 .. The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
 .. ``In-N-Out Burger`` and replace it with a new document with a ``name`` value of ``Shake Shack``.
@@ -150,7 +154,7 @@ does not match any existing documents.
    :dedent:
 
 
-The following code shows how to use the ``hint`` option to optimize the query performance of the ``replace_one()`` method:
+The following code uses the ``hint`` option to optimize query performance when performing a replace operation. 
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-options-hint
@@ -158,10 +162,11 @@ The following code shows how to use the ``hint`` option to optimize the query pe
    :language: cpp
    :dedent:
 
-The above example uses :ref:`create_index() <cpp-indexes>` to create an ascending single-field index using the ``name`` field. 
+The above code uses :ref:`create_index() <cpp-indexes>` to create an ascending single-field index using the ``name`` field. 
 The name of this index, ``name_1``, is then passed as an argument to the ``hint`` member function of ``opts``, an instance of the 
-``mongocxx::options::replace`` class. ``opts`` is then passed as the third argument to the ``replace_one()`` function, which replaces
- a document with a ``name`` field value of ``Nobu` with a new document with a ``name`` field value of ``La Bernadin``.
+``mongocxx::options::replace`` class. Because ``opts`` is passed in as its third argument, the ``replace_one()`` method searches through the 
+``name_1`` index for a ``name`` value of ``Nobu``. The matching document is then replaced with a new document with a ``name`` value of ``La Bernadin``. 
+To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexes>`.
 
 Return Value
 ~~~~~~~~~~~~
@@ -196,24 +201,46 @@ member functions:
 Examples 
 ^^^^^^^^
 
-The following example uses the ``replace_one()`` to replace the fields and values
-of a document in which the ``name`` field value is ``Nobu`` with a new
-document in which the ``name`` field value is ``La Bernadin``. It calls the
-``modified_count()`` member function to print the number of modified documents 
-and the ``matched_documents()`` member function to print the number of matched documents: 
+.. The following example uses the ``replace_one()`` to replace the fields and values
+.. of a document in which the ``name`` field value is ``Nobu`` with a new
+.. document in which the ``name`` field value is ``La Bernadin``. It calls the
+.. ``modified_count()`` member function to print the number of modified documents 
+.. and the ``matched_documents()`` member function to print the number of matched documents: 
+
+The following code uses the ``matched_documents()`` member functiotn to return the number of 
+documents that the ``replace_one()`` method found while searching for a 
+document with a ``name`` field value of ``Shake Shack``. It then uses the
+``modified_documents()`` member function to print the number of documents that the ``replace_one()`` function
+replaced with a new document with a ``name`` value of ``In-N-Out Burger``: 
 
 .. io-code-block::
 
    .. input:: /includes/write/replace.cpp
-      :start-after: start-replace-result
-      :end-before: end-replace-result
+      :start-after: start-replace-result-matched
+      :end-before: end-replace-result-matched
       :language: cpp
       :dedent:
 
    .. output:: 
 
+      Matched documents: 11
       Modified documents: 1
-      Matched documents: 10
+
+The following code uses the ``upserted_id()`` member function to return the ``_id`` field value of 
+the document that the ``replace_one()`` method upserts into the database when it does not match any 
+existing document with a ``name`` field value of ``In-N-Out Burger``:
+
+.. io-code-block::
+
+   .. input:: /includes/write/replace.cpp
+      :start-after: start-replace-result-upsert
+      :end-before: end-replace-result-upsert
+      :language: cpp
+      :dedent:
+
+   .. output:: 
+
+      Upserted ID: 67128c5ecc1f8c15ea26fcf8
 
 Additional Information 
 ----------------------

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -21,7 +21,7 @@ Overview
 --------
 
 In this guide, you can learn how to use the {+driver-short+} to run a replace operation on a MongoDB collection.
-A replace operation removes *all* fields in the target document and replaces them with new ones.
+A replace operation removes all fields except the ``_id`` field in the target document and replaces them with new ones.
 You can call the ``replace_one()`` method to replace a single document.
 
 Sample Data

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -38,8 +38,8 @@ and assign the following values to your ``db`` and ``collection`` variables:
     :language: cpp
     :dedent:
 
-To learn how to create a free MongoDB Atlas cluster and load the sample datasets, see
-:atlas:`Get Started with Atlas </getting-started>`.
+To learn how to create a free MongoDB Atlas cluster and load the sample datasets, see the
+:atlas:`Get Started with Atlas </getting-started>` guide.
 
 Replace Operation
 -----------------

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -66,8 +66,8 @@ Replace One Document Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example uses the ``replace_one()`` method to replace 
-a document that has a ``name`` field value of ``Nobu`` with a new document 
-that has a ``name`` field value of ``La Bernadin``:
+a document that has a ``name`` field value of ``"Nobu"`` with a new document 
+that has a ``name`` field value of ``"La Bernadin"``:
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-one
@@ -159,7 +159,7 @@ Example: ``hint``
 The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
 on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts`` and sets its ``hints`` field value to the name 
 of the new index, ``name_1``. When ``opts`` is passed in as an optional argument, the ``replace_one()`` method searches the ``name_1`` index for a
-``name`` field value of ``Nobu`` and replaces the associated document with a new document that has a ``name`` field value of ``La Bernadin``.  
+``name`` field value of ``"Nobu"`` and replaces the associated document with a new document that has a ``name`` field value of ``"La Bernadin"``.  
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-options-hint
@@ -174,9 +174,9 @@ Example: ``upsert``
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
 and sets its ``upsert`` field value to ``true``.  When ``opts`` is passed in as an optional argument, the ``replace_one()`` method
-searches the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
+searches the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``"In-N-Out Burger"``. 
 Because this sample collection does not contain a document matching this query filter,
-the ``replace_one()`` method upserts a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
+the ``replace_one()`` method upserts a new document with a ``name`` field value of ``"Shake Shack"`` into the collection. 
 
 .. io-code-block::
 
@@ -227,9 +227,9 @@ Example: ``matched_count()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``replace_one()`` method to replace a document that has
-a ``name`` field value of ``Shake Shack`` with a new document that has a ``name`` 
-field value of ``In-N-Out Burger``. It then calls the ``matched_count()`` member 
-function to print the number of documents that match the search for a ``name`` field value of ``Shake Shack``:
+a ``name`` field value of ``"Shake Shack"`` with a new document that has a ``name`` 
+field value of ``"In-N-Out Burger"``. It then calls the ``matched_count()`` member 
+function to print the number of documents that match the search for a ``name`` field value of ``"Shake Shack"``:
 
 .. io-code-block::
 
@@ -248,7 +248,7 @@ function to print the number of documents that match the search for a ``name`` f
 Example: ``upserted_id()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following example uses the ``replace_one()`` method to find and replace a document that has a ``name`` field value of ``In-N-Out Burger``. 
+The following example uses the ``replace_one()`` method to find and replace a document that has a ``name`` field value of ``"In-N-Out Burger"``. 
 Because the upsert option is set to true, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
 It then cals the ``upserted_id()`` member function to print the ``_id`` field value of the upserted document. 
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -163,10 +163,15 @@ Example: ``upsert``
 ^^^^^^^^^^^^^^^^^^^
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
-and sets ``opts``'s ``upsert`` field to ``true``. It passes ``opts`` to the ``replace_one()`` 
-method, which then scans the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
+and sets its ``upsert`` field value to ``true``. It then passes ``opts`` to the ``replace_one()`` 
+method, which scans the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
 Because there is no matching document in the collection, the ``replace_one()`` method upserts
 a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
+
+.. The following example uses the ``replace_one()`` method to find and replace a document with a ``name`` field value of ``In-N-Out Burger``. 
+.. Because the upsert option is set to true, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
+.. The following example then uses the ``upserted_id()`` member function to print the ``_id`` field value of 
+.. the upserted document, which has a ``name`` field value of ``Shake Shack``. 
 
 .. io-code-block::
 
@@ -234,10 +239,9 @@ function to print the number of matched documents:
 Example: ``upserted_id()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following example uses the ``upserted_id()`` member function to return the ``_id`` field value of 
-the document that the ``replace_one()`` method upserts into the database when it can not find any 
-existing document with a ``name`` field value of ``In-N-Out Burger``. The upserted document
-has a ``name`` field value of ``Shake Shack``. 
+The following example uses the ``replace_one()`` method to find and replace a document with a ``name`` field value of ``In-N-Out Burger``. 
+Because the upsert option is set to true, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
+Then, the ``upserted_id()`` member function is called to print the ``_id`` field value of the upserted document. 
 
 .. io-code-block::
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -175,9 +175,9 @@ Example: ``upsert``
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
 and sets its ``upsert`` field value to ``true``. It then passes ``opts`` to the ``replace_one()`` 
-method, which searches the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
-Because there is no matching document in the collection, the ``replace_one()`` method upserts
-a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
+method, which searches the collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
+Because the ``sample_restaurants.restaurants`` collection does not contain a document that matches this query filter,
+the ``replace_one()`` method upserts a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
 
 .. io-code-block::
 
@@ -191,8 +191,8 @@ a new document with a ``name`` field value of ``Shake Shack`` into the collectio
       :language: cli
       :visible: false
       
-      Number of documents before replace: 25359
-      Number of documents after replace: 25360
+      Total document count before replace_one(): 25359
+      Total document count after replace_one(): 25360
 
 Return Value
 ~~~~~~~~~~~~
@@ -249,7 +249,7 @@ function to print the number of documents that match the search for a ``name`` f
 Example: ``upserted_id()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following example uses the ``replace_one()`` method to find and replace a document with a ``name`` field value of ``In-N-Out Burger``. 
+The following example uses the ``replace_one()`` method to find and replace a document that has a ``name`` field value of ``In-N-Out Burger``. 
 Because the upsert option is set to true, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
 It then cals the ``upserted_id()`` member function to print the ``_id`` field value of the upserted document. 
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -48,7 +48,7 @@ You can perform a replace operation by calling the ``replace_one()`` method.
 This method removes all fields except the ``_id`` field from the first document that
 matches the search criteria. It then inserts the fields and values you specify into the document. 
 
-Each replace method requires the following parameters:
+The ``replace_one()`` method requires the following parameters:
 
 - **Query filter** document: Specifies which document to replace. For
   more information about query filters, see 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -60,10 +60,9 @@ Each replace method requires the following parameters:
 Replace One Document Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example uses the ``replace_one()`` method to find 
-a document with a ``name`` field value of ``Nobu`` and replace it 
-with a new document with a ``name`` field value of ``La Bernadin``. 
-It then prints the resulting document: 
+The following example uses the ``replace_one()`` method to replace 
+a document that has a ``name`` field value of ``Nobu`` with a new document 
+that has a ``name`` field value of ``La Bernadin``:
 
 .. io-code-block::
 
@@ -141,11 +140,10 @@ argument. The following table describes the fields you can set in a
 ^^^^^^^^^^^^^^^^
 
 The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
-on the ``name`` field. Then, it instantiates a ``mongocxx::options::replace`` object called ``opts``
-and sets ``opts``'s ``hint`` field to the name of the new index, ``name_1``. 
-It passes ``opts`` to the ``replace_one()`` method, which then scans the ``name_1`` index 
-to find a document with a ``name`` field value of ``Nobu`` and replace it with a 
-new document with a ``name`` field value of ``La Bernadin``.  
+on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts``
+and sets ``opts``'s ``hint`` field to the name of the new index, ``name_1``. With ``opts`` passed in as an argument, the 
+``replace_one()`` method searches the ``name_1`` index for a document with a ``name`` field value of ``Nobu``. This document is 
+then replaced with a new document that has a ``name`` field value of ``La Bernadin``.
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-options-hint

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -75,7 +75,7 @@ that has a ``name`` field value of ``La Bernadin``:
    :language: cpp
    :dedent:
 
-To check if you successfully created the collection, you can print out a list of all collections in the database:
+To check if you successfully replaced the document, you can use the ``find_one()`` method to print out the new document:
 
 .. io-code-block::
 
@@ -90,7 +90,6 @@ To check if you successfully created the collection, you can print out a list of
       :visible: false
       
       New document: { "_id" : { "$oid" : "5eb3d668b31de5d588f42e34" }, "name" : "La Bernadin" }  
-
 
 Options 
 ~~~~~~~
@@ -158,11 +157,10 @@ argument. The following table describes the fields you can set in a
 Example: ``hint``
 ^^^^^^^^^^^^^^^^^
 
-The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
-on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts``
-and sets ``opts``'s ``hint`` field to the name of the new index, ``name_1``. With ``opts`` passed in as an argument, the 
-``replace_one()`` method searches the ``name_1`` index for a document with a ``name`` field value of ``Nobu``. This document is 
-then replaced with a new document that has a ``name`` field value of ``La Bernadin``.
+The following example uses the ``:ref:`create_index() <cpp-indexes>``` method to create an ascending single-field index 
+on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts`` and sets its ``hints`` field value to the name 
+of the new index, ``name_1``. It then passes ``opts`` in to the ``replace_one()`` method, which searches the ``name_1`` index for a
+``name`` field value of ``Nobu`` and replaces the associated document with a new document that has a ``name`` field value of ``La Bernadin``.  
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-options-hint
@@ -172,20 +170,14 @@ then replaced with a new document that has a ``name`` field value of ``La Bernad
 
 To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexes>`.
 
-
 Example: ``upsert`` 
 ^^^^^^^^^^^^^^^^^^^
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
 and sets its ``upsert`` field value to ``true``. It then passes ``opts`` to the ``replace_one()`` 
-method, which scans the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
+method, which searches the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
 Because there is no matching document in the collection, the ``replace_one()`` method upserts
 a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
-
-.. The following example uses the ``replace_one()`` method to find and replace a document with a ``name`` field value of ``In-N-Out Burger``. 
-.. Because the upsert option is set to true, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
-.. The following example then uses the ``upserted_id()`` member function to print the ``_id`` field value of 
-.. the upserted document, which has a ``name`` field value of ``Shake Shack``. 
 
 .. io-code-block::
 
@@ -196,6 +188,8 @@ a new document with a ``name`` field value of ``Shake Shack`` into the collectio
       :dedent:
 
    .. output:: 
+      :language: cli
+      :visible: false
       
       Number of documents before replace: 25359
       Number of documents after replace: 25360

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -75,7 +75,7 @@ that has a ``name`` field value of ``"La Bernadin"``:
    :language: cpp
    :dedent:
 
-To check if you successfully replaced the document, you can use the :ref:`find_one() <cpp-retrieve-find-one>` method to print out the new document:
+To check if you successfully replaced the document, you can use the find_one() method to print out the new document:
 
 .. io-code-block::
 
@@ -90,6 +90,8 @@ To check if you successfully replaced the document, you can use the :ref:`find_o
       :visible: false
       
       New document: { "_id" : { "$oid" : "5eb3d668b31de5d588f42e34" }, "name" : "La Bernadin" }  
+
+To learn more about the find_one() method, see :ref:`cpp-retrieve-find-one` in the Retrieve Data guide.
 
 Options 
 ~~~~~~~

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -99,7 +99,7 @@ Options
 You can modify the behavior of the ``replace_one()`` method by
 passing an instance of the ``mongocxx::options::replace`` class as an optional
 argument. The following table describes the fields you can set in a
-``mongocxx::options::update`` instance:
+``mongocxx::options::replace`` instance:
 
 .. list-table::
    :widths: 30 70

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -120,11 +120,11 @@ argument. The following table describes the fields you can set in a
      - | Specifies a comment of any valid BSON type to attach to the operation. 
          Once set, this comment appears alongside records of this command in the following locations:
 
-        - :ref:`mongod log messages <log-messages-ref>`, in the
-          ``attr.command.cursor.comment`` field
-        - :ref:`Database profiler output <profiler>`, in the :data:`system.profile.command <system.profile.command>` ``comment`` field
-        - :dbcommand:`currentOp` output, in the :data:`currentOp.command
-          <currentOp.command>` ``comment`` field
+         - :ref:`mongod log messages <log-messages-ref>`, in the
+           ``attr.command.cursor.comment`` field
+         - :ref:`Database profiler output <profiler>`, in the :data:`system.profile.command <system.profile.command>` ``comment`` field
+         - :dbcommand:`currentOp` output, in the :data:`currentOp.command
+           <currentOp.command>` ``comment`` field
 
        | For more information, see the :manual:`insert Command
          Fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -159,7 +159,7 @@ Example: ``hint``
 
 The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
 on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts`` and sets its ``hints`` field value to the name 
-of the new index, ``name_1``. It then passes ``opts`` in to the ``replace_one()`` method, which searches the ``name_1`` index for a
+of the new index, ``name_1``. When ``opts`` is passed in as an optional argument, the ``replace_one()`` method searches the ``name_1`` index for a
 ``name`` field value of ``Nobu`` and replaces the associated document with a new document that has a ``name`` field value of ``La Bernadin``.  
 
 .. literalinclude:: /includes/write/replace.cpp
@@ -174,9 +174,9 @@ Example: ``upsert``
 ^^^^^^^^^^^^^^^^^^^
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
-and sets its ``upsert`` field value to ``true``. It then passes ``opts`` to the ``replace_one()`` 
-method, which searches the collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
-Because the ``sample_restaurants.restaurants`` collection does not contain a document that matches this query filter,
+and sets its ``upsert`` field value to ``true``.  When ``opts`` is passed in as an optional argument, the ``replace_one()`` method
+searches the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
+Because this sample collection does not contain a document matching this query filter,
 the ``replace_one()`` method upserts a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
 
 .. io-code-block::

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -110,20 +110,22 @@ argument. The following table describes the fields you can set in a
          - Database profiler output, in the command.comment field.
          - currentOp output, in the command.comment field. 
 
-         For more information, see ``comment`` in the {+mdb-server+} manual :manual:` insert command
-         fields guide </reference/command/insert/#command-fields>`.
+         For more information, see the :manual:`insert command
+         fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.
 
    * - ``hint``
      - | Specifies the index to scan for documents that match the query filter.
-         For more information, see ``hint`` in the {+mdb-server+} manual 
-         :manual:`update statement fields guide </reference/command/update/#std-label-update-statement-documents>`. 
+         For more information, see the
+         :manual:`update statement fields guide </reference/command/update/#std-label-update-statement-documents>`
+         in the {+mdb-server+} manual. 
 
    * - ``let``
      - | Specifies a document containing variables and their values to be used in the ``replace_one()`` method. 
          This allows you to improve code readability by separating the variables from the operation text. 
        | Values must be constant or closed expressions that don't reference document fields. 
-         For more information, see ``let`` in the {+mdb-server+} manual 
-         :manual:`update command fields guide </reference/command/update/#std-label-replace-let-syntax>`.
+         For more information, see the 
+         :manual:`update command fields guide </reference/command/update/#std-label-replace-let-syntax>`
+         in the {+mdb-server+} manual.
 
    * - ``upsert``
      - | Specifies whether the replace operation performs an upsert operation if no 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -120,11 +120,11 @@ argument. The following table describes the fields you can set in a
      - | Specifies a comment of any valid BSON type to attach to the operation. 
          Once set, this comment appears alongside records of this command in the following locations:
 
-         - :ref:`mongod log messages <log-messages-ref>`, in the
-           ``attr.command.cursor.comment`` field
-         - :ref:`Database profiler output <profiler>`, in the :data:`system.profile.command <system.profile.command>` ``comment`` field
-         - :dbcommand:`currentOp` output, in the :data:`currentOp.command
-           <currentOp.command>` ``comment`` field
+       - :ref:`mongod log messages <log-messages-ref>`, in the
+         ``attr.command.cursor.comment`` field
+       - :ref:`Database profiler output <profiler>`, in the :data:`system.profile.command <system.profile.command>` ``comment`` field
+       - :dbcommand:`currentOp` output, in the :data:`currentOp.command
+         <currentOp.command>` ``comment`` field
 
        | For more information, see the :manual:`insert Command
          Fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -38,8 +38,8 @@ and assign the following values to your ``db`` and ``collection`` variables:
     :language: cpp
     :dedent:
 
-To learn how to create a free MongoDB Atlas cluster and load the sample datasets, see the
-:atlas:`Get Started with Atlas </getting-started>` guide.
+To learn how to create a free MongoDB Atlas cluster and load the sample datasets, see
+:atlas:`Get Started with Atlas </getting-started>`.
 
 Replace Operation
 -----------------
@@ -51,8 +51,8 @@ matches the search criteria. It then inserts the fields and values you specify i
 Each replace method requires the following parameters:
 
 - **Query filter** document: Specifies which document to replace. For
-  more information about query filters, see the 
-  :manual:`Query Filter Documents section </core/document/#query-filter-documents>` in
+  more information about query filters, see 
+  :manual:`Query Filter Documents </core/document/#query-filter-documents>` in
   the {+mdb-server+} manual.
 
 - **Replace** document: Specifies the fields and values to insert in the new document. 
@@ -270,7 +270,7 @@ It then cals the ``upserted_id()`` member function to print the ``_id`` field va
 Additional Information 
 ----------------------
 
-To learn more about creating query filters, see the :ref:`cpp-specify-query` guide.
+To learn more about creating query filters, see :ref:`cpp-specify-query`.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -57,6 +57,11 @@ Each replace method requires the following parameters:
 
 - **Replace** document: Specifies the fields and values to insert in the new document. 
 
+.. important:: 
+
+   The values of ``_id`` fields are immutable. If your replacement document specifies a value for the _id field, 
+   it must match the _id value of the existing document.
+
 Replace One Document Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -136,8 +141,8 @@ argument. The following table describes the fields you can set in a
          For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
 
-``hint`` Example 
-^^^^^^^^^^^^^^^^
+Example: ``hint``
+^^^^^^^^^^^^^^^^^
 
 The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
 on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts``
@@ -154,8 +159,8 @@ then replaced with a new document that has a ``name`` field value of ``La Bernad
 To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexes>`.
 
 
-``upsert`` Example  
-^^^^^^^^^^^^^^^^^^
+Example: ``upsert`` 
+^^^^^^^^^^^^^^^^^^^
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
 and sets ``opts``'s ``upsert`` field to ``true``. It passes ``opts`` to the ``replace_one()`` 
@@ -206,8 +211,8 @@ member functions:
      - | Returns the ID of the document that was upserted in the database, if the driver
          performed an upsert.
 
-``matched_documents()`` Example
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Example: ``matched_count()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``replace_one()`` to replace a document with 
 a ``name`` field value of ``Shake Shack`` with a new document with a ``name`` 
@@ -226,7 +231,7 @@ function to print the number of matched documents:
 
       Matched documents: 11
 
-``upserted_id()`` Example
+Example: ``upserted_id()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``upserted_id()`` member function to return the ``_id`` field value of 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -132,11 +132,16 @@ parameter. This class contains the following member functions:
 Examples 
 ^^^^^^^^
 .. example:: 
-The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
-``In-N-Out Burger`` and replace it with a new document describing a restaurant with a ``name`` value of ``7th Street Burger``.
-Because the ``upsert`` option is set to ``true`` and the ``sample_restaurants.restaurants`` collection 
-does not contain a document with a ``name`` value of ``In-N-Out Burger``,
-the {+driver-short+} inserts a new document into the collection rather than replacing an existing document: 
+The following code uses the ``upsert`` option set to ``true`` in order to insert a new document with a ``name``
+value of ``Shake Shack`` if its search for a *Query Filter* document with a ``name`` value of ``In-N-Out Burger`` 
+does not match any existing documents. 
+ 
+.. The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
+.. ``In-N-Out Burger`` and replace it with a new document with a ``name`` value of ``Shake Shack``.
+.. Because the ``upsert`` option is set to ``true`` and the ``sample_restaurants.restaurants`` collection 
+.. does not contain a document with a ``name`` value of ``In-N-Out Burger``,
+.. the {+driver-short+} inserts a new document into the collection when the operation can not find
+.. an existing document with a ``name`` value of ``In-N-Out Burger``.  than replacing an existing document: 
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-options-upsert

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -107,9 +107,9 @@ instance of the class using the dot operator ``(.)``.
          {+mdb-server+} manual for more information.
 
    * - ``hint``
-     - | Sets the index to scan for documents. Accepts an instance of the mongocxx::v_noabi::hint class representing an
+     - | Specifies the index to search for the **Query Filter** document. Accepts an instance of the mongocxx::v_noabi::hint class representing an
          index name.
-         For more information, see the :manual:`hint statement </reference/command/update/#std-label-update-command-hint>`
+       | For more information, see the :manual:`hint statement </reference/command/update/#std-label-update-command-hint>`
          in the {+mdb-server+} manual.
 
    * - ``let``
@@ -131,8 +131,8 @@ instance of the class using the dot operator ``(.)``.
          For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
 
-The following uses the ``replace_one()`` method to attempt to replace a document with a ``name`` value of 
-``In-N-Out Burger`` with a new document describing a restaurant with a ``name`` value of ``7th Street Burger``.
+The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
+``In-N-Out Burger`` and replace it with a new document describing a restaurant with a ``name`` value of ``7th Street Burger``.
 Because the ``upsert`` option is set to ``true`` and the ``sample_restaurants.restaurants`` collection 
 does not contain a document with a ``name`` value of ``In-N-Out Burger``,
 the {+driver-short+} inserts a new document into the collection rather than replacing an existing document: 
@@ -142,6 +142,30 @@ the {+driver-short+} inserts a new document into the collection rather than repl
    :end-before: end-replace-options-upsert
    :language: cpp
    :dedent:
+
+.. The following example uses the ``replace_one()`` method to search for a *Query-Filter* document 
+.. with the ``name`` field value of ``Nobu`` and replace it with a *Replace* document with the
+.. ``name`` field value of ``La Bernadin``. To find the *Query-Filter* document 
+.. The following example uses the ``hint`` option to search for a *Query-Filter* document 
+.. with a ``name`` field value indexed in an ascending single-field index. 
+
+
+The following code shows how to use the ``hint`` option to optimize the query performance of the ``replace_one()`` method:
+
+.. literalinclude:: /includes/write/replace.cpp
+   :start-after: start-replace-options-hint
+   :end-before: end-replace-options-hint
+   :language: cpp
+   :dedent:
+
+The above example uses `create_index() <cpp-indexes>` to create an ascending single-field index using the ``name`` field. 
+The name of this index, ``name_1``, is then passed as an argument to the ``hint`` member function of ``opts``, an instance of the 
+``mongocxx::options::replace`` class. ``opts`` is then passed as the third argument to the ``replace_one()`` function, which replaces
+ a document with a ``name`` field value of ``Nobu` with a new document with a ``name`` field value of ``La Bernadin``.
+
+.. to optimize the search for a *Query-Filter* document with a ``name`` field value of ``Nobu``. When this document 
+.. is found, it is replaced by a new document with a ``name`` field value of ``La Bernadin``. 
+.. created using the ``name`` field. 
 
 Return Value
 ~~~~~~~~~~~~

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -7,7 +7,7 @@ Replace Documents
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 3
+   :depth: 2
    :class: singlecol
 
 .. facet::
@@ -60,22 +60,29 @@ Each replace method requires the following parameters:
 Replace One Document Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example uses the ``replace_one()`` method to replace the fields and values
-of a document in which the ``name`` field value is ``Bagels N Buns``:
+The following example uses the ``replace_one()`` method to find 
+a document with a ``name`` field value of ``Nobu`` and replace it 
+with a new document with a ``name`` field value of ``La Bernadin``:
 
-.. literalinclude:: /includes/write/replace.cpp
-   :start-after: start-replace-one
-   :end-before: end-replace-one
-   :language: cpp
-   :dedent:
+.. io-code-block::
 
+   .. input:: /includes/write/replace.cpp
+      :start-after: start-replace-one
+      :end-before: end-replace-one
+      :language: cpp
+      :dedent:
+   
+   .. output:: 
+      
+      New document: { "_id" : { "$oid" : "5eb3d668b31de5d588f42e34" }, "name" : "La Bernadin" }
 
 Options 
 ~~~~~~~
 
 You can modify the behavior of the ``replace_one()`` method by
 passing an instance of the ``mongocxx::options::replace`` class as an optional
-parameter. This class contains the following member functions:
+parameter. The following table describes the fields you can set in a
+``mongocxx::options::update`` instance:
 
 .. list-table::
    :widths: 30 70
@@ -84,43 +91,38 @@ parameter. This class contains the following member functions:
    * - Function 
      - Description
 
-   * - ``bypass_document_validation(<bool bypass_document_validation>)``
-     - | Specifies whether the replace operation bypasses document validation. Accepts a boolean value as its argument. 
-       | When set to ``true``, this lets you replace a document with a new document that doesn't meet the schema validation requirements. 
-       | For more information, see :manual:`Schema Validation </core/schema-validation/#schema-validation>` in the {+mdb-server+} manual.
+   * - ``bypass_document_validation``
+     - | Specifies whether the replace operation bypasses document validation. When set to ``true``, this lets you replace a document with a new document that doesn't meet the schema validation requirements. 
+         For more information, see :manual:`Schema Validation </core/schema-validation/#schema-validation>` in the {+mdb-server+} manual.
        | Defaults to ``false``.
 
    * - ``collation(<document::view_or_value collation>)``
      - | Specifies the kind of language collation to use when sorting
-         results. Accepts a :manual:`collation document </reference/collation/#collation-document>` as its argument.
-       | For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
+         results. For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
          in the {+mdb-server+} manual.
 
    * - ``comment(<bson_value::view_or_value comment>)``
-     - | Specifies a comment to attach to the operation. Accepts a comment of any valid BSON type as its argument (string, integer, object, array, etc).
-       | Once set, this comment appears alongside records of this command in the following locations:
+     - | Specifies a comment of any valid BSON type to attach to the operation. 
+         Once set, this comment appears alongside records of this command in the following locations:
+
          - mongod log messages, in the attr.command.cursor.comment field.
          - Database profiler output, in the command.comment field.
          - currentOp output, in the command.comment field. 
-       | For more information, see the :manual:`insert command
-         fields </reference/command/insert/#command-fields>` guide in the
-         {+mdb-server+} manual. 
+
+         For more information, see ``comment`` in the {+mdb-server+} manual :manual:` insert command
+         fields guide </reference/command/insert/#command-fields>`.
 
    * - ``hint``
-     - | Specifies the index to search for the **Query Filter** document. Accepts as its argument an instance of the mongocxx::v_noabi::hint class representing an
-         index name.
-       | For more information, see the :manual:`hint statement </reference/command/update/#std-label-update-command-hint>`
-         in the {+mdb-server+} manual.
+     - | Specifies the index to scan for documents that match the query filter.
+         For more information, see ``hint`` in the {+mdb-server+} manual 
+         :manual:`update statement fields guide </reference/command/update/#std-label-update-statement-documents>`. 
 
    * - ``let``
-     - | Specifies variables and their values to be used in the ``replace_one()`` method. 
-         Accepts as its argument a document containing variable-value pairs. To access the value of a variable in the method, 
-         use the double dollar sign prefix ($$) together with your variable name in the form ``$$<variable-name>``. 
-       | This allows you to improve command readability by separating 
-         the variables from the query text.
-       | For more information, see :manual:`let 
-         </reference/command/update/#std-label-replace-let-syntax>` in the
-         {+mdb-server+} manual.
+     - | Specifies a document containing variables and their values to be used in the ``replace_one()`` method. 
+         This allows you to improve code readability by separating the variables from the operation text. 
+       | Values must be constant or closed expressions that don't reference document fields. 
+         For more information, see ``let`` in the {+mdb-server+} manual 
+         :manual:`update command fields guide </reference/command/update/#std-label-replace-let-syntax>`.
 
    * - ``upsert``
      - | Specifies whether the replace operation performs an upsert operation if no 
@@ -129,32 +131,18 @@ parameter. This class contains the following member functions:
 
    * - ``write_concern``
      - | Sets the write concern for the operation.
-       | For more information, see :manual:`Write Concern </reference/write-concern/>`
+         For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
 
-Examples 
-^^^^^^^^
+``hint`` Example 
+^^^^^^^^^^^^^^^^
 
-The following code uses the ``replace_one()`` function with an ``upsert`` option set to ``true``
-to insert a new document with a ``name`` value of ``Shake Shack`` into the ``sample_restaurants.restaurants`` collection 
-when its search for a document with a ``name`` value of ``In-N-Out Burger`` 
-does not match an existing document: 
- 
-.. The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
-.. ``In-N-Out Burger`` and replace it with a new document with a ``name`` value of ``Shake Shack``.
-.. Because the ``upsert`` option is set to ``true`` and the ``sample_restaurants.restaurants`` collection 
-.. does not contain a document with a ``name`` value of ``In-N-Out Burger``,
-.. the {+driver-short+} inserts a new document into the collection when the operation can not find
-.. an existing document with a ``name`` value of ``In-N-Out Burger``.  than replacing an existing document: 
-
-.. literalinclude:: /includes/write/replace.cpp
-   :start-after: start-replace-options-upsert
-   :end-before: end-replace-options-upsert
-   :language: cpp
-   :dedent:
-
-
-The following code uses the ``hint`` option to optimize query performance when performing a replace operation. 
+The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
+on the ``name`` field. Then, it instantiates a ``mongocxx::options::replace`` object called ``opts``
+and sets ``opts``'s ``hint`` field to the name of the new index, ``name_1``. 
+It passes ``opts`` to the ``replace_one()`` method, which then scans the ``name_1`` index 
+to find a document with a ``name`` field value of ``Nobu`` and replace it with a 
+new document with a ``name`` field value of ``La Bernadin``.  
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-options-hint
@@ -162,11 +150,30 @@ The following code uses the ``hint`` option to optimize query performance when p
    :language: cpp
    :dedent:
 
-The above code uses :ref:`create_index() <cpp-indexes>` to create an ascending single-field index using the ``name`` field. 
-The name of this index, ``name_1``, is then passed as an argument to the ``hint`` member function of ``opts``, an instance of the 
-``mongocxx::options::replace`` class. Because ``opts`` is passed in as its third argument, the ``replace_one()`` method searches through the 
-``name_1`` index for a ``name`` value of ``Nobu``. The matching document is then replaced with a new document with a ``name`` value of ``La Bernadin``. 
 To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexes>`.
+
+
+``upsert`` Example  
+^^^^^^^^^^^^^^^^^^
+
+The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
+and sets ``opts``'s ``upsert`` field to ``true``. It passes ``opts`` to the ``replace_one()`` 
+method, which then scans the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger`. 
+Because there is no matching document in the collection, the ``replace_one()`` method upserts
+a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
+
+.. io-code-block::
+
+   .. input:: /includes/write/replace.cpp
+      :start-after: start-replace-options-upsert
+      :end-before: end-replace-options-upsert
+      :language: cpp
+      :dedent:
+
+   .. output:: 
+      
+      Number of documents before replace: 25359
+      Number of documents after replace: 25360
 
 Return Value
 ~~~~~~~~~~~~
@@ -198,20 +205,13 @@ member functions:
      - | Returns the ID of the document that was upserted in the database, if the driver
          performed an upsert.
 
-Examples 
-^^^^^^^^
+``matched_documents()`` Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. The following example uses the ``replace_one()`` to replace the fields and values
-.. of a document in which the ``name`` field value is ``Nobu`` with a new
-.. document in which the ``name`` field value is ``La Bernadin``. It calls the
-.. ``modified_count()`` member function to print the number of modified documents 
-.. and the ``matched_documents()`` member function to print the number of matched documents: 
-
-The following code uses the ``matched_documents()`` member functiotn to return the number of 
-documents that the ``replace_one()`` method found while searching for a 
-document with a ``name`` field value of ``Shake Shack``. It then uses the
-``modified_documents()`` member function to print the number of documents that the ``replace_one()`` function
-replaced with a new document with a ``name`` value of ``In-N-Out Burger``: 
+The following example uses the ``replace_one()`` to replace a document with 
+a ``name`` field value of ``Shake Shack`` with a new document with a ``name`` 
+field value of ``In-N-Out Burger``. It calls the ``matched_count()`` member 
+function to print the number of matched documents:
 
 .. io-code-block::
 
@@ -224,11 +224,14 @@ replaced with a new document with a ``name`` value of ``In-N-Out Burger``:
    .. output:: 
 
       Matched documents: 11
-      Modified documents: 1
 
-The following code uses the ``upserted_id()`` member function to return the ``_id`` field value of 
-the document that the ``replace_one()`` method upserts into the database when it does not match any 
-existing document with a ``name`` field value of ``In-N-Out Burger``:
+``upserted_id()`` Example
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following example uses the ``upserted_id()`` member function to return the ``_id`` field value of 
+the document that the ``replace_one()`` method upserts into the database when it can not find any 
+existing document with a ``name`` field value of ``In-N-Out Burger``. The upserted document
+has a ``name`` field value of ``Shake Shack``. 
 
 .. io-code-block::
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -75,48 +75,41 @@ Customize the Replace Operation
 
 You can modify the behavior of the ``replace_one()`` method by
 passing an instance of the ``mongocxx::options::replace`` class as an optional
-parameter. The following table describes the fields you can set in a
-``mongocxx::options::replace`` instance:
+parameter. The following table describes the public member functions of the 
+``mongocxx::options::replace`` class. You can call these public functions on an 
+instance of the class using the dot operator ``(.)``. 
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Field
+   * - Public Member Function 
      - Description
 
-   * - ``upsert``
-     - | Specifies whether the replace operation performs an upsert operation if no 
-         documents match the query filter. For more information, see the :manual:`upsert
-         statement </reference/command/replace/#std-label-replace-command-upsert>`
-         in the {+mdb-server+} manual.
-       | Defaults to ``false``.
-
-   * - ``bypass_document_validation``
-     - | Specifies whether the replace operation bypasses document validation. This lets you 
-         replace documents that don't meet the schema validation requirements, if any 
-         exist. For more information about schema validation, see :manual:`Schema
+   * - ``bypass_document_validation(<bool bypass_document_validation>)``
+     - | Specifies whether the replace operation bypasses document validation. When set to ``true``,
+         this lets you replace a document with a new document that doesn't meet the schema validation requirements. 
+         For more information about schema validation, see :manual:`Schema
          Validation </core/schema-validation/#schema-validation>` in the MongoDB
          Server manual.
        | Defaults to ``false``.
 
-   * - ``collation``
+   * - ``collation(<document::view_or_value collation>)``
      - | Specifies the kind of language collation to use when sorting
-         results. For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
+         results. Accepts a `collation document </reference/collation/#collation-document>` as its argument.
+       | For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
          in the {+mdb-server+} manual.
 
-   * - ``array_filters``
-     - | Specifies which array elements an replace applies to if the operation modifies
-         array fields.
+   * - ``comment(<bson_value::view_or_value comment>)``
+     - | Specifies a comment to attach to the operation. Accepts a comment of any BSON type as its argument.
+       | For more information, see the :manual:`insert command
+         fields </reference/command/insert/#command-fields>` guide in the
+         {+mdb-server+} manual for more information.
 
    * - ``hint``
-     - | Sets the index to scan for documents. 
-         For more information, see the :manual:`hint statement </reference/command/replace/#std-label-replace-command-hint>`
-         in the {+mdb-server+} manual.
-
-   * - ``write_concern``
-     - | Sets the write concern for the operation.
-         For more information, see :manual:`Write Concern </reference/write-concern/>`
+     - | Sets the index to scan for documents. Accepts an instance of the mongocxx::v_noabi::hint class representing an
+         index name.
+         For more information, see the :manual:`hint statement </reference/command/update/#std-label-update-command-hint>`
          in the {+mdb-server+} manual.
 
    * - ``let``
@@ -126,29 +119,29 @@ parameter. The following table describes the fields you can set in a
          </reference/command/replace/#std-label-replace-let-syntax>` in the
          {+mdb-server+} manual.
 
-   * - ``comment``
-     - | A comment to attach to the operation. For more information, see the :manual:`insert command
-         fields </reference/command/insert/#command-fields>` guide in the
-         {+mdb-server+} manual for more information.
+   * - ``upsert``
+     - | Specifies whether the replace operation performs an upsert operation if no 
+         documents match the query filter. For more information, see the :manual:`upsert
+         statement </reference/command/replace/#std-label-replace-command-upsert>`
+         in the {+mdb-server+} manual.
+       | Defaults to ``false``.
 
-:red:`CHANGE THIS CHANGE THIS CHANGE THIS` 
-You want to modify your restaurant list to exactly one burger restaurant, preferably in Manhattan. 
-The following example uses the ``replace_one()`` method to replace the first document that it encounters with a 
-``borough`` value of ``Manhattan`` with a different document containing information about a restaurant with the 
-``name`` value ``Chicken Fingers`` and the ``borough`` value ``Brooklyn``.  and replace a document that has
-a ``borough`` value of ``"Manhattan"``.
+   * - ``write_concern``
+     - | Sets the write concern for the operation.
+         For more information, see :manual:`Write Concern </reference/write-concern/>`
+         in the {+mdb-server+} manual.
 
-Because the ``upsert`` option is
-set to ``true``, the {+driver-short+} inserts a new document if the query filter doesn't 
-match any existing documents.
+The following uses the ``replace_one()`` method to attempt to replace a document with a ``name`` value of 
+``In-N-Out Burger`` with a new document describing a restaurant with a ``name`` value of ``7th Street Burger``.
+Because the ``upsert`` option is set to ``true`` and the ``sample_restaurants.restaurants`` collection 
+does not contain a document with a ``name`` value of ``In-N-Out Burger``,
+the {+driver-short+} inserts a new document into the collection rather than replacing an existing document: 
 
 .. literalinclude:: /includes/write/replace.cpp
-   :start-after: start-replace-options
-   :end-before: end-replace-options
+   :start-after: start-replace-options-upsert
+   :end-before: end-replace-options-upsert
    :language: cpp
    :dedent:
-
-:red:`CHANGE THIS CHANGE THIS CHANGE THIS` 
 
 Return Value
 ~~~~~~~~~~~~
@@ -176,14 +169,12 @@ member functions:
    * - ``result()``
      - | Returns the bulk write result for the operation.
 
-   * - ``upserted_count()``
-     - | Returns the number of documents that were upserted into the database.
-
    * - ``upserted_id()``
      - | Returns the ID of the document that was upserted in the database, if the driver
          performed an upsert.
         
-The following example uses the ``replace_one()`` method to replace the fields and values
+The following example uses the ``replace_one()`` method with an instance of the ``mongocxx::options::replace`` class as an optional
+parameter to replace the fields and values
 of the first document in which the  ``borough`` field value is ``Brooklyn`` with a different
 document for a restaurant with the ``name`` field value ``McDonald's``. It calls the
 ``modified_count()`` member function to print the number of modified documents 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -20,7 +20,7 @@ Replace Documents
 Overview
 --------
 
-In this guide, you can learn how to use the {+driver-short+} to run a replace operation on a MongoDB collection.
+In this guide, you can learn how to use the {+driver-short+} to run a **replace operation** on a MongoDB collection.
 A replace operation removes all fields except the ``_id`` field in the target document and replaces them with new ones.
 You can call the ``replace_one()`` method to replace a single document.
 
@@ -133,8 +133,7 @@ argument. The following table describes the fields you can set in a
 
    * - ``hint``
      - | Specifies the index to scan for documents that match the query filter.
-         For more information, see the
-         :manual:`Update Statement fields guide </reference/command/update/#std-label-update-statement-documents>`
+         For more information, see the :manual:`hint field </reference/command/update/#std-label-update-command-hint>`
          in the {+mdb-server+} manual. 
 
    * - ``let``

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -57,8 +57,8 @@ Each replace method requires the following parameters:
 
 - **Replace** document: Specifies the fields and values to insert in the new document. 
 
-Replace One Document
-~~~~~~~~~~~~~~~~~~~~
+Replace One Document Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example uses the ``replace_one()`` method to replace the fields and values
 of a document in which the ``name`` field value is ``Bagels N Buns``:
@@ -70,8 +70,8 @@ of a document in which the ``name`` field value is ``Bagels N Buns``:
    :dedent:
 
 
-Customize the Replace Operation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Options 
+~~~~~~~
 
 You can modify the behavior of the ``replace_one()`` method by
 passing an instance of the ``mongocxx::options::replace`` class as an optional
@@ -131,6 +131,7 @@ instance of the class using the dot operator ``(.)``.
          For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
 
+
 The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
 ``In-N-Out Burger`` and replace it with a new document describing a restaurant with a ``name`` value of ``7th Street Burger``.
 Because the ``upsert`` option is set to ``true`` and the ``sample_restaurants.restaurants`` collection 
@@ -186,7 +187,10 @@ member functions:
    * - ``upserted_id()``
      - | Returns the ID of the document that was upserted in the database, if the driver
          performed an upsert.
-        
+
+Examples 
+^^^^^^^^
+       
 The following example uses the ``replace_one()`` method with an instance of the ``mongocxx::options::replace`` class as an optional
 parameter to replace the fields and values
 of the first document in which the  ``borough`` field value is ``Brooklyn`` with a different

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -110,29 +110,33 @@ argument. The following table describes the fields you can set in a
      - | Specifies a comment of any valid BSON type to attach to the operation. 
          Once set, this comment appears alongside records of this command in the following locations:
 
-       - mongod log messages, in the ``attr.command.cursor.comment`` field.
-       - Database profiler output, in the ``command.comment`` field.
-       - currentOp output, in the ``command.comment`` field. 
-       | For more information, see the :manual:`insert command
-         fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.
+        - :ref:`mongod log messages <log-messages-ref>`, in the
+          ``attr.command.cursor.comment`` field.
+        - :ref:`Database profiler <profiler>` output, in the :data:`command.comment
+          <system.profile.command>` field.
+        - :dbcommand:`currentOp` output, in the :data:`command.comment
+        <currentOp.command>` field.
+        
+       | For more information, see the :manual:`insert Command
+         Fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.
 
    * - ``hint``
      - | Specifies the index to scan for documents that match the query filter.
          For more information, see the
-         :manual:`update statement fields guide </reference/command/update/#std-label-update-statement-documents>`
+         :manual:`Update Statement fields guide </reference/command/update/#std-label-update-statement-documents>`
          in the {+mdb-server+} manual. 
 
    * - ``let``
      - | Specifies a document containing variables and their values to be used in the ``replace_one()`` method. 
          This allows you to improve code readability by separating the variables from the operation text. 
-       | Values must be constant or closed expressions that don't reference document fields. 
+         Values must be constant or closed expressions that don't reference document fields. 
          For more information, see the 
-         :manual:`update command fields guide </reference/command/update/#std-label-replace-let-syntax>`
+         :manual:`update Command Fields guide </reference/command/update/#std-label-replace-let-syntax>`
          in the {+mdb-server+} manual.
 
    * - ``upsert``
      - | Specifies whether the replace operation performs an upsert operation if no 
-         documents match the query filter. Accepts a boolean value as its argument. 
+         documents match the query filter.
        | Defaults to ``false``.
 
    * - ``write_concern``

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -107,14 +107,14 @@ parameter. This class contains the following member functions:
          {+mdb-server+} manual. 
 
    * - ``hint``
-     - | Specifies the index to search for the **Query Filter** document. Accepts an instance of the mongocxx::v_noabi::hint class representing an
+     - | Specifies the index to search for the **Query Filter** document. Accepts as its argument an instance of the mongocxx::v_noabi::hint class representing an
          index name.
        | For more information, see the :manual:`hint statement </reference/command/update/#std-label-update-command-hint>`
          in the {+mdb-server+} manual.
 
    * - ``let``
      - | Specifies variables and their values to be used in the ``replace_one()`` method. 
-         Accepts a document containing variable-value pairs. To access the value of a variable in the method, 
+         Accepts as its argument a document containing variable-value pairs. To access the value of a variable in the method, 
          use the double dollar sign prefix ($$) together with your variable name in the form ``$$<variable-name>``. 
        | This allows you to improve command readability by separating 
          the variables from the query text.

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -59,8 +59,8 @@ Each replace method requires the following parameters:
 
 .. important:: 
 
-   The values of ``_id`` fields are immutable. If your replacement document specifies a value for the _id field, 
-   it must match the _id value of the existing document.
+   The values of ``_id`` fields are immutable. If your replacement document specifies a value for the ``_id`` field, 
+   it must match the ``_id`` value of the existing document.
 
 Replace One Document Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -62,7 +62,8 @@ Replace One Document Example
 
 The following example uses the ``replace_one()`` method to find 
 a document with a ``name`` field value of ``Nobu`` and replace it 
-with a new document with a ``name`` field value of ``La Bernadin``:
+with a new document with a ``name`` field value of ``La Bernadin``. 
+It then prints the resulting document: 
 
 .. io-code-block::
 
@@ -81,7 +82,7 @@ Options
 
 You can modify the behavior of the ``replace_one()`` method by
 passing an instance of the ``mongocxx::options::replace`` class as an optional
-parameter. The following table describes the fields you can set in a
+argument. The following table describes the fields you can set in a
 ``mongocxx::options::update`` instance:
 
 .. list-table::
@@ -96,12 +97,12 @@ parameter. The following table describes the fields you can set in a
          For more information, see :manual:`Schema Validation </core/schema-validation/#schema-validation>` in the {+mdb-server+} manual.
        | Defaults to ``false``.
 
-   * - ``collation(<document::view_or_value collation>)``
+   * - ``collation``
      - | Specifies the kind of language collation to use when sorting
          results. For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
          in the {+mdb-server+} manual.
 
-   * - ``comment(<bson_value::view_or_value comment>)``
+   * - ``comment``
      - | Specifies a comment of any valid BSON type to attach to the operation. 
          Once set, this comment appears alongside records of this command in the following locations:
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -75,7 +75,7 @@ that has a ``name`` field value of ``"La Bernadin"``:
    :language: cpp
    :dedent:
 
-To check if you successfully replaced the document, you can use the find_one() method to print out the new document:
+To check if you successfully replaced the document, you can use the ``find_one()`` method to print out the new document:
 
 .. io-code-block::
 
@@ -89,9 +89,9 @@ To check if you successfully replaced the document, you can use the find_one() m
       :language: cli
       :visible: false
       
-      New document: { "_id" : { "$oid" : "5eb3d668b31de5d588f42e34" }, "name" : "La Bernadin" }  
+      New document: { "_id" : { "$oid" : "..." }, "name" : "La Bernadin" }  
 
-To learn more about the find_one() method, see :ref:`cpp-retrieve-find-one` in the Retrieve Data guide.
+To learn more about the ``find_one()`` method, see :ref:`cpp-retrieve-find-one` in the Retrieve Data guide.
 
 Options 
 ~~~~~~~
@@ -141,7 +141,7 @@ argument. The following table describes the fields you can set in a
          This allows you to improve code readability by separating the variables from the operation text. 
          Values must be constant or closed expressions that don't reference document fields. 
          For more information, see the 
-         :manual:`update Command Fields guide </reference/command/update/#std-label-replace-let-syntax>`
+         :manual:`let field </reference/command/update/#std-label-update-let-syntax>`
          in the {+mdb-server+} manual.
 
    * - ``upsert``
@@ -168,7 +168,7 @@ field index when replacing a document that has a ``name`` field value of ``"Nobu
    :language: cpp
    :dedent:
 
-To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexes>`.
+To learn more about indexes, see the :ref:`Optimize Queries with Indexes <cpp-indexes>` guide.
 
 Example: upsert Option
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -270,7 +270,7 @@ Then, the code calls the ``upserted_id()`` member function to print the ``_id`` 
 Additional Information 
 ----------------------
 
-To learn more about creating query filters, see :ref:`cpp-specify-query`.
+To learn more about creating query filters, see the :ref:`cpp-specify-query` guide.
 
 API Documentation
 ~~~~~~~~~~~~~~~~~

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -230,7 +230,7 @@ Example: matched_count()
 The following example uses the ``replace_one()`` method to replace a document that has
 a ``name`` field value of ``"Shake Shack"`` with a new document that has a ``name`` 
 field value of ``"In-N-Out Burger"``. It then calls the ``matched_count()`` member 
-function to print the number of documents that match the search for a ``name`` field value of ``"Shake Shack"``:
+function to print the number of documents that match the query filter:
 
 .. io-code-block::
 
@@ -249,9 +249,9 @@ function to print the number of documents that match the search for a ``name`` f
 Example: upserted_id()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following example uses the ``replace_one()`` method to find and replace a document that has a ``name`` field value of ``"In-N-Out Burger"``. 
-Because the upsert option is set to true, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
-It then cals the ``upserted_id()`` member function to print the ``_id`` field value of the upserted document. 
+The following example uses the ``replace_one()`` method to replace a document that has a ``name`` field value of ``"In-N-Out Burger"``. 
+Because the ``upsert`` option is set to ``true``, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 
+Then, the code calls the ``upserted_id()`` member function to print the ``_id`` field value of the upserted document: 
 
 .. io-code-block::
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -158,10 +158,10 @@ argument. The following table describes the fields you can set in a
 Example: hint
 ^^^^^^^^^^^^^^^^^
 
-The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
-on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts`` and sets its ``hints`` field value to the name 
-of the new index, ``name_1``. When ``opts`` is passed in as an optional argument, the ``replace_one()`` method searches the ``name_1`` index for a
-``name`` field value of ``"Nobu"`` and replaces the associated document with a new document that has a ``name`` field value of ``"La Bernadin"``.  
+The following example uses the ``create_index()`` method to create an ascending single-field index 
+on the ``name`` field. It then passes a ``mongocxx::options::replace`` object to the ``replace_one()``
+method after setting its ``hint`` field to the new index. This instructs the replace operation to search the ``name`` 
+field index when replacing a document that has a ``name`` field value of ``"Nobu"``:
 
 .. literalinclude:: /includes/write/replace.cpp
    :start-after: start-replace-options-hint

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -1,0 +1,218 @@
+.. _cpp-write-replace:
+
+================
+Replace Documents
+================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: modify, change, bulk, code example
+
+Overview
+--------
+
+In this guide, you can learn how to use the {+driver-short+} to run a replace operation on a MongoDB collection.
+A replace operation removes *all* fields in the target document and replaces them with new ones.
+You can call the ``replace_one()`` method to replace a single document.
+
+Sample Data
+~~~~~~~~~~~
+
+The examples in this guide use the ``restaurants`` collection in the ``sample_restaurants``
+database from the :atlas:`Atlas sample datasets </sample-data>`. To access this collection
+from your C++ application, instantiate a ``mongocxx::client`` that connects to an Atlas cluster
+and assign the following values to your ``db`` and ``collection`` variables:
+
+.. literalinclude:: /includes/write/replace.cpp
+    :start-after: start-db-coll
+    :end-before: end-db-coll
+    :language: cpp
+    :dedent:
+
+To learn how to create a free MongoDB Atlas cluster and load the sample datasets, see the
+:atlas:`Get Started with Atlas </getting-started>` guide.
+
+Replace Operation
+-----------------
+
+You can perform a replace operation by calling the ``replace_one()`` method.
+This method removes all fields except the ``_id`` field from the first document that
+matches the search criteria. It then inserts the fields and values you specify into the document. 
+
+Each replace method requires the following parameters:
+
+- **Query filter** document: Specifies which document to replace. For
+  more information about query filters, see the 
+  :manual:`Query Filter Documents section </core/document/#query-filter-documents>` in
+  the {+mdb-server+} manual.
+
+- **Replace** document: Specifies the fields and values to insert in the new document. 
+
+Replace One Document
+~~~~~~~~~~~~~~~~~~~
+
+The following example uses the ``replace_one()`` method to replace the fields and values
+of a document in which the ``name`` field value is ``Bagels N Buns``:
+
+.. literalinclude:: /includes/write/replace.cpp
+   :start-after: start-replace-one
+   :end-before: end-replace-one
+   :language: cpp
+   :dedent:
+
+
+Customize the Replace Operation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can modify the behavior of the ``replace_one()`` method by
+passing an instance of the ``mongocxx::options::replace`` class as an optional
+parameter. The following table describes the fields you can set in a
+``mongocxx::options::replace`` instance:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Field
+     - Description
+
+   * - ``upsert``
+     - | Specifies whether the replace operation performs an upsert operation if no 
+         documents match the query filter. For more information, see the :manual:`upsert
+         statement </reference/command/replace/#std-label-replace-command-upsert>`
+         in the {+mdb-server+} manual.
+       | Defaults to ``false``.
+
+   * - ``bypass_document_validation``
+     - | Specifies whether the replace operation bypasses document validation. This lets you 
+         replace documents that don't meet the schema validation requirements, if any 
+         exist. For more information about schema validation, see :manual:`Schema
+         Validation </core/schema-validation/#schema-validation>` in the MongoDB
+         Server manual.
+       | Defaults to ``false``.
+
+   * - ``collation``
+     - | Specifies the kind of language collation to use when sorting
+         results. For more information, see :manual:`Collation </reference/collation/#std-label-collation>`
+         in the {+mdb-server+} manual.
+
+   * - ``array_filters``
+     - | Specifies which array elements an replace applies to if the operation modifies
+         array fields.
+
+   * - ``hint``
+     - | Sets the index to scan for documents. 
+         For more information, see the :manual:`hint statement </reference/command/replace/#std-label-replace-command-hint>`
+         in the {+mdb-server+} manual.
+
+   * - ``write_concern``
+     - | Sets the write concern for the operation.
+         For more information, see :manual:`Write Concern </reference/write-concern/>`
+         in the {+mdb-server+} manual.
+
+   * - ``let``
+     - | Specifies a document with a list of values to improve operation readability.
+         Values must be constant or closed expressions that don't reference document
+         fields. For more information, see the :manual:`let statement
+         </reference/command/replace/#std-label-replace-let-syntax>` in the
+         {+mdb-server+} manual.
+
+   * - ``comment``
+     - | A comment to attach to the operation. For more information, see the :manual:`insert command
+         fields </reference/command/insert/#command-fields>` guide in the
+         {+mdb-server+} manual for more information.
+
+:red:`CHANGE THIS CHANGE THIS CHANGE THIS` 
+You want to modify your restaurant list to exactly one burger restaurant, preferably in Manhattan. 
+The following example uses the ``replace_one()`` method to replace the first document that it encounters with a 
+``borough`` value of ``Manhattan`` with a different document containing information about a restaurant with the 
+``name`` value ``Chicken Fingers`` and the ``borough`` value ``Brooklyn``.  and replace a document that has
+a ``borough`` value of ``"Manhattan"``.
+
+Because the ``upsert`` option is
+set to ``true``, the {+driver-short+} inserts a new document if the query filter doesn't 
+match any existing documents.
+
+.. literalinclude:: /includes/write/replace.cpp
+   :start-after: start-replace-options
+   :end-before: end-replace-options
+   :language: cpp
+   :dedent:
+
+:red:`CHANGE THIS CHANGE THIS CHANGE THIS` 
+
+Return Value
+~~~~~~~~~~~~
+
+The ``replace_one()`` method returns an instance of
+the ``mongocxx::result::replace`` class. This class contains the following
+member functions:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Function
+     - Description
+
+   * - ``matched_count()``
+     - | Returns the number of documents that matched the query filter, regardless of
+         how many were replaced.
+
+   * - ``modified_count()``
+     - | Returns number of documents modified by the replace operation. If a replaced
+         document is identical to the original, it is not included in this
+         count.
+         
+   * - ``result()``
+     - | Returns the bulk write result for the operation.
+
+   * - ``upserted_count()``
+     - | Returns the number of documents that were upserted into the database.
+
+   * - ``upserted_id()``
+     - | Returns the ID of the document that was upserted in the database, if the driver
+         performed an upsert.
+        
+The following example uses the ``replace_one()`` method to replace the fields and values
+of the first document in which the  ``borough`` field value is ``Brooklyn`` with a different
+document for a restaurant with the ``name`` field value ``McDonald's``. It calls the
+``modified_count()`` member function to print the number of modified documents 
+and the ``matched_documents()`` member function to print the number of matched documents: 
+
+.. io-code-block::
+
+   .. input:: /includes/write/replace.cpp
+      :start-after: start-replace-result
+      :end-before: end-replace-result
+      :language: cpp
+      :dedent:
+
+   .. output:: 
+
+      Modified documents: 1
+      Matched documents: 10
+
+Additional Information 
+----------------------
+
+To learn more about creating query filters, see the :ref:`cpp-specify-query` guide.
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+To learn more about any of the methods or types discussed in this
+guide, see the following API documentation:
+
+- `replace_one() <{+api+}/classmongocxx_1_1model_1_1replace__one.html>`__
+- `mongocxx::options::replace <{+api+}/classmongocxx_1_1v__noabi_1_1options_1_1replace.html>`__
+- `mongocxx::result::replace <{+api+}/classmongocxx_1_1v__noabi_1_1result_1_1replace__one.html>`__

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -155,7 +155,7 @@ argument. The following table describes the fields you can set in a
          For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
 
-Example: ``hint``
+Example: hint
 ^^^^^^^^^^^^^^^^^
 
 The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
@@ -171,7 +171,7 @@ of the new index, ``name_1``. When ``opts`` is passed in as an optional argument
 
 To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexes>`.
 
-Example: ``upsert`` 
+Example: upsert 
 ^^^^^^^^^^^^^^^^^^^
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
@@ -225,7 +225,7 @@ member functions:
      - | Returns the ID of the document that was upserted in the database, if the driver
          performed an upsert.
 
-Example: ``matched_count()``
+Example: matched_count()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``replace_one()`` method to replace a document that has
@@ -247,7 +247,7 @@ function to print the number of documents that match the search for a ``name`` f
 
       Matched documents: 11
 
-Example: ``upserted_id()``
+Example: upserted_id()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``replace_one()`` method to find and replace a document that has a ``name`` field value of ``"In-N-Out Burger"``. 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -110,7 +110,7 @@ argument. The following table describes the fields you can set in a
      - | Specifies a comment of any valid BSON type to attach to the operation. 
          Once set, this comment appears alongside records of this command in the following locations:
 
-         - mongod log messages, in the attr.command.cursor.comment field.
+       | - mongod log messages, in the attr.command.cursor.comment field.
          - Database profiler output, in the command.comment field.
          - currentOp output, in the command.comment field. 
 
@@ -164,7 +164,7 @@ Example: ``upsert``
 
 The following example instantiates a ``mongocxx::options::replace`` object called ``opts``
 and sets ``opts``'s ``upsert`` field to ``true``. It passes ``opts`` to the ``replace_one()`` 
-method, which then scans the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger`. 
+method, which then scans the ``sample_restaurants.restaurants`` collection for a document with a ``name`` field value of ``In-N-Out Burger``. 
 Because there is no matching document in the collection, the ``replace_one()`` method upserts
 a new document with a ``name`` field value of ``Shake Shack`` into the collection. 
 
@@ -214,8 +214,8 @@ member functions:
 Example: ``matched_count()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following example uses the ``replace_one()`` to replace a document with 
-a ``name`` field value of ``Shake Shack`` with a new document with a ``name`` 
+The following example uses the ``replace_one()`` to replace a document that has
+a ``name`` field value of ``Shake Shack`` with a new document that has a ``name`` 
 field value of ``In-N-Out Burger``. It calls the ``matched_count()`` member 
 function to print the number of matched documents:
 
@@ -232,7 +232,7 @@ function to print the number of matched documents:
       Matched documents: 11
 
 Example: ``upserted_id()``
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``upserted_id()`` member function to return the ``_id`` field value of 
 the document that the ``replace_one()`` method upserts into the database when it can not find any 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -154,8 +154,8 @@ argument. The following table describes the fields you can set in a
          For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
 
-Example: hint
-^^^^^^^^^^^^^^^^^
+Example: hint Option
+^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``create_index()`` method to create an ascending single-field index 
 on the ``name`` field. It then passes a ``mongocxx::options::replace`` object to the ``replace_one()``
@@ -170,8 +170,8 @@ field index when replacing a document that has a ``name`` field value of ``"Nobu
 
 To learn more about indexes, see :ref:`Optimize Queries with Indexes <cpp-indexes>`.
 
-Example: upsert 
-^^^^^^^^^^^^^^^^^^^
+Example: upsert Option
+^^^^^^^^^^^^^^^^^^^^^^
 
 The following example passes a ``mongocxx::options::replace`` object to the ``replace_one()`` method 
 after setting its ``upsert`` field value to ``true``.  
@@ -224,7 +224,7 @@ member functions:
          performed an upsert.
 
 Example: matched_count()
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``replace_one()`` method to replace a document that has
 a ``name`` field value of ``"Shake Shack"`` with a new document that has a ``name`` 
@@ -246,7 +246,7 @@ function to print the number of documents that match the query filter:
       Matched documents: 11
 
 Example: upserted_id()
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
 
 The following example uses the ``replace_one()`` method to replace a document that has a ``name`` field value of ``"In-N-Out Burger"``. 
 Because the ``upsert`` option is set to ``true``, the {+driver-short+} inserts a new document when the query filter doesn't match any existing documents. 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -197,7 +197,7 @@ member functions:
    :widths: 30 70
    :header-rows: 1
 
-   * - Function
+   * - Field
      - Description
 
    * - ``matched_count()``

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -75,7 +75,7 @@ that has a ``name`` field value of ``La Bernadin``:
    :language: cpp
    :dedent:
 
-To check if you successfully replaced the document, you can use the ``find_one()`` method to print out the new document:
+To check if you successfully replaced the document, you can use the :ref:`find_one() <cpp-retrieve-find-one>` method to print out the new document:
 
 .. io-code-block::
 
@@ -157,7 +157,7 @@ argument. The following table describes the fields you can set in a
 Example: ``hint``
 ^^^^^^^^^^^^^^^^^
 
-The following example uses the ``:ref:`create_index() <cpp-indexes>``` method to create an ascending single-field index 
+The following example uses the :ref:`create_index() <cpp-indexes>` method to create an ascending single-field index 
 on the ``name`` field. It then instantiates a ``mongocxx::options::replace`` object called ``opts`` and sets its ``hints`` field value to the name 
 of the new index, ``name_1``. It then passes ``opts`` in to the ``replace_one()`` method, which searches the ``name_1`` index for a
 ``name`` field value of ``Nobu`` and replaces the associated document with a new document that has a ``name`` field value of ``La Bernadin``.  
@@ -241,6 +241,8 @@ function to print the number of documents that match the search for a ``name`` f
       :dedent:
 
    .. output:: 
+      :language: cli
+      :visible: false
 
       Matched documents: 11
 
@@ -260,6 +262,8 @@ It then cals the ``upserted_id()`` member function to print the ``_id`` field va
       :dedent:
 
    .. output:: 
+      :language: cli
+      :visible: false
 
       Upserted ID: 67128c5ecc1f8c15ea26fcf8
 

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -7,7 +7,7 @@ Replace Documents
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 3
    :class: singlecol
 
 .. facet::
@@ -130,7 +130,9 @@ instance of the class using the dot operator ``(.)``.
      - | Sets the write concern for the operation.
          For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
-
+         
+Examples 
+^^^^^^^^
 
 The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
 ``In-N-Out Burger`` and replace it with a new document describing a restaurant with a ``name`` value of ``7th Street Burger``.
@@ -190,7 +192,7 @@ member functions:
 
 Examples 
 ^^^^^^^^
-       
+
 The following example uses the ``replace_one()`` method with an instance of the ``mongocxx::options::replace`` class as an optional
 parameter to replace the fields and values
 of the first document in which the  ``borough`` field value is ``Brooklyn`` with a different

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -110,11 +110,10 @@ argument. The following table describes the fields you can set in a
      - | Specifies a comment of any valid BSON type to attach to the operation. 
          Once set, this comment appears alongside records of this command in the following locations:
 
-       | - mongod log messages, in the attr.command.cursor.comment field.
-         - Database profiler output, in the command.comment field.
-         - currentOp output, in the command.comment field. 
-
-         For more information, see the :manual:`insert command
+       - mongod log messages, in the ``attr.command.cursor.comment`` field.
+       - Database profiler output, in the ``command.comment`` field.
+       - currentOp output, in the ``command.comment`` field. 
+       | For more information, see the :manual:`insert command
          fields guide </reference/command/insert/#command-fields>` in the {+mdb-server+} manual.
 
    * - ``hint``

--- a/source/write/replace.txt
+++ b/source/write/replace.txt
@@ -75,15 +75,13 @@ Options
 
 You can modify the behavior of the ``replace_one()`` method by
 passing an instance of the ``mongocxx::options::replace`` class as an optional
-parameter. The following table describes the public member functions of the 
-``mongocxx::options::replace`` class. You can call these public functions on an 
-instance of the class using the dot operator ``(.)``. 
+parameter. This class contains the following member functions:
 
 .. list-table::
    :widths: 30 70
    :header-rows: 1
 
-   * - Public Member Function 
+   * - Function 
      - Description
 
    * - ``bypass_document_validation(<bool bypass_document_validation>)``
@@ -130,10 +128,10 @@ instance of the class using the dot operator ``(.)``.
      - | Sets the write concern for the operation.
          For more information, see :manual:`Write Concern </reference/write-concern/>`
          in the {+mdb-server+} manual.
-         
+
 Examples 
 ^^^^^^^^
-
+.. example:: 
 The following code uses the ``replace_one()`` method to find a document with a ``name`` value of 
 ``In-N-Out Burger`` and replace it with a new document describing a restaurant with a ``name`` value of ``7th Street Burger``.
 Because the ``upsert`` option is set to ``true`` and the ``sample_restaurants.restaurants`` collection 
@@ -193,10 +191,9 @@ member functions:
 Examples 
 ^^^^^^^^
 
-The following example uses the ``replace_one()`` method with an instance of the ``mongocxx::options::replace`` class as an optional
-parameter to replace the fields and values
-of the first document in which the  ``borough`` field value is ``Brooklyn`` with a different
-document for a restaurant with the ``name`` field value ``McDonald's``. It calls the
+The following example uses the ``replace_one()`` to replace the fields and values
+of a document in which the ``name`` field value is ``Nobu`` with a new
+document in which the ``name`` field value is ``La Bernadin``. It calls the
 ``modified_count()`` member function to print the number of modified documents 
 and the ``matched_documents()`` member function to print the number of matched documents: 
 


### PR DESCRIPTION
# Pull Request Info
Added a new page documenting the replace_one() method. 

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - [DOCSP-39838](https://jira.mongodb.org/browse/DOCSP-39838)
Staging - 
- [Replace Documents](https://deploy-preview-62--docs-cpp.netlify.app/write/replace/) 
- [Write Data to MongoDB](https://deploy-preview-62--docs-cpp.netlify.app/write/#replace-one)
## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?