### PR TITLE
DOCSP-45566: Update current in redirects file

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -2,7 +2,7 @@ define: prefix docs/languages/cpp/cpp-driver
 define: base https://www.mongodb.com/${prefix}
 define: versions v3.10 3.11 master
 
-symlink: current -> v3.10
+symlink: current -> v3.11
 symlink: upcoming -> master
 
 raw: ${prefix}/ -> ${base}/current/


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

Fixes an issue where v3.10 redirects were being applied to "current" (v3.11) links. This fix isn't visible from the staging link.

JIRA - https://jira.mongodb.org/browse/DOCSP-45566
Staging - https://deploy-preview-77--docs-cpp.netlify.app/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?