### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/api-abi-versioning.txt
+++ b/source/api-abi-versioning.txt
@@ -4,6 +4,9 @@
 API and ABI Versioning
 ======================
 
+.. meta::
+   :description: Understand the API and ABI versioning for the C++ driver, including header file structure, library filenames, and the use of CMake package config files.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/api-abi-versioning/abi-versioning.txt
+++ b/source/api-abi-versioning/abi-versioning.txt
@@ -4,6 +4,9 @@
 ABI Versioning
 ===============
 
+.. meta::
+   :description: Understand how the C++ Driver uses ABI versioning to manage stability and compatibility for shared libraries, including the use of ABI namespaces and versioning policies.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/api-abi-versioning/api-versioning.txt
+++ b/source/api-abi-versioning/api-versioning.txt
@@ -4,6 +4,9 @@
 API Versioning
 ===============
 
+.. meta::
+   :description: Understand how the C++ Driver uses Semantic Versioning for API versioning, distinguishing between public and private APIs, and handling deprecations.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,9 @@
 MongoDB C++ Driver
 ===================
 
+.. meta::
+   :description: Explore the MongoDB C++ Driver, including installation, connection setup, data operations, and advanced configuration options.
+
 .. facet::
    :name: genre
    :values: reference

--- a/source/testing.txt
+++ b/source/testing.txt
@@ -5,7 +5,7 @@ Testing
 =======
 
 .. meta::
-   :description: Learn how to run and write tests for the C++11 driver using Catch, including unit and integration tests.
+   :description: Learn how to run and write tests for the C++ driver using Catch, including unit and integration tests.
 
 .. contents:: On this page
    :local:

--- a/source/testing.txt
+++ b/source/testing.txt
@@ -4,6 +4,9 @@
 Testing
 =======
 
+.. meta::
+   :description: Learn how to run and write tests for the C++11 driver using Catch, including unit and integration tests.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/thread-safety.txt
+++ b/source/thread-safety.txt
@@ -4,6 +4,9 @@
 Thread and Fork Safety
 =======================
 
+.. meta::
+   :description: Ensure each thread has its own `mongocxx::client` and avoid sharing client objects across threads to maintain thread safety in C++ MongoDB applications.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/thread-safety.txt
+++ b/source/thread-safety.txt
@@ -5,7 +5,7 @@ Thread and Fork Safety
 =======================
 
 .. meta::
-   :description: Ensure each thread has its own `mongocxx::client` and avoid sharing client objects across threads to maintain thread safety in C++ MongoDB applications.
+   :description: Ensure each thread has its own mongocxx::client and avoid sharing client objects across threads to maintain thread safety in C++ MongoDB applications.
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539