### PR TITLE
DOCSP-49002 Auto-downloaded C Driver incorrectly inherits BUILD_VERSION

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -45,10 +45,12 @@ The v4.0 driver release includes the following new features:
 The release includes the following bug:
 
 - CMake might incorrectly set the API version (``BUILD_VERSION``) for an 
-  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ driver's 
-  API version. CMake will only auto-download the C driver with the C++ driver 
-  if it cannot find an existing C driver installation. This ``BUILD_VERSION`` 
-  error will be fixed in an upcoming patch release. 
+  auto-downloaded C driver to ``0.0.0`` when the CMake project is configured 
+  more than once or to the same value as the C++ driver's 
+  API version when ``BUILD_VERSION`` is explicitly set during initial configuration. 
+  CMake will only auto-download the C driver with the C++ driver 
+  if it cannot find an existing C driver installation via ``find_package()``. 
+  This bug will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the
 `v4.0 Release Notes <https://github.com/mongodb/mongo-cxx-driver/releases/tag/r4.0.0>`__
@@ -76,10 +78,12 @@ The v3.11 driver release includes the following new features:
 The release includes the following bug:
 
 - CMake might incorrectly set the API version (``BUILD_VERSION``) for an 
-  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ driver's 
-  API version. CMake will only auto-download the C driver with the C++ driver 
-  if it cannot find an existing C driver installation. This ``BUILD_VERSION`` 
-  error will be fixed in an upcoming patch release. 
+  auto-downloaded C driver to ``0.0.0`` when the CMake project is configured 
+  more than once or to the same value as the C++ driver's 
+  API version when ``BUILD_VERSION`` is explicitly set during initial configuration. 
+  CMake will only auto-download the C driver with the C++ driver 
+  if it cannot find an existing C driver installation via ``find_package()``. 
+  This bug will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the
 `v3.11 Release Notes <https://github.com/mongodb/mongo-cxx-driver/releases/tag/r3.11.0>`__

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -42,6 +42,18 @@ The v4.0 driver release includes the following new features:
 - Adds a getter method for the ``start_at_operation_time`` field of a 
   ``mongocxx::options::change_stream`` instance.
 
+The release includes the following bug:
+
+- CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
+  auto-downloaded C driver to 0.0.0 or to the same value as the C++'s Drivers 
+  API version. CMake will only auto-download the C Driver with the C++ Driver 
+  if it cannot find an existing C Driver installation. This will be fixed in 
+  an upcoming patch release. 
+
+To learn more about this release, see the
+`v4.0 Release Notes <https://github.com/mongodb/mongo-cxx-driver/releases/tag/r4.0.0>`__
+on GitHub.
+
 .. _version-3.11:
 
 What's New in 3.11
@@ -60,6 +72,14 @@ The v3.11 driver release includes the following new features:
   more information about Queryable Encryption, see :manual:`Queryable
   Encryption </core/queryable-encryption>` in the {+mdb-server+} manual.
 - Adds ``empty()`` member function for ``mongocxx::v_noabi::bulk_write``.
+
+The release includes the following bug:
+
+- CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
+  auto-downloaded C driver to 0.0.0 or to the same value as the C++'s Drivers 
+  API version. CMake will only auto-download the C Driver with the C++ Driver 
+  if it cannot find an existing C Driver installation. This will be fixed in 
+  an upcoming patch release. 
 
 To learn more about this release, see the
 `v3.11 Release Notes <https://github.com/mongodb/mongo-cxx-driver/releases/tag/r3.11.0>`__

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -49,7 +49,7 @@ The release includes the following bug:
   more than once or to the same value as the C++ driver's 
   API version when ``BUILD_VERSION`` is explicitly set during initial configuration. 
   CMake will only auto-download the C driver with the C++ driver 
-  if it cannot find an existing C driver installation via ``find_package()``. 
+  if it cannot find an existing C driver installation by using ``find_package()``. 
   This bug will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the
@@ -82,7 +82,7 @@ The release includes the following bug:
   more than once or to the same value as the C++ driver's 
   API version when ``BUILD_VERSION`` is explicitly set during initial configuration. 
   CMake will only auto-download the C driver with the C++ driver 
-  if it cannot find an existing C driver installation via ``find_package()``. 
+  if it cannot find an existing C driver installation by using ``find_package()``. 
   This bug will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -44,7 +44,7 @@ The v4.0 driver release includes the following new features:
 
 The release includes the following bug:
 
-- CMake might incorrectly set the API version (``BUILD_VERSION``) for an 
+- CMake might incorrectly set the API version for an 
   auto-downloaded C driver to ``0.0.0`` when the CMake project is configured 
   more than once or to the same value as the C++ driver's 
   API version when ``BUILD_VERSION`` is explicitly set during initial configuration. 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -44,10 +44,10 @@ The v4.0 driver release includes the following new features:
 
 The release includes the following bug:
 
-- CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
-  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ Driver's 
-  API version. CMake will only auto-download the C Driver with the C++ Driver 
-  if it cannot find an existing C Driver installation. This ``BUILD_VERSION`` 
+- CMake might incorrectly set the API version (``BUILD_VERSION``) for an 
+  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ driver's 
+  API version. CMake will only auto-download the C driver with the C++ driver 
+  if it cannot find an existing C driver installation. This ``BUILD_VERSION`` 
   error will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the
@@ -75,10 +75,10 @@ The v3.11 driver release includes the following new features:
 
 The release includes the following bug:
 
-- CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
-  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ Driver's 
-  API version. CMake will only auto-download the C Driver with the C++ Driver 
-  if it cannot find an existing C Driver installation. This ``BUILD_VERSION`` 
+- CMake might incorrectly set the API version (``BUILD_VERSION``) for an 
+  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ driver's 
+  API version. CMake will only auto-download the C driver with the C++ driver 
+  if it cannot find an existing C driver installation. This ``BUILD_VERSION`` 
   error will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -77,7 +77,7 @@ The v3.11 driver release includes the following new features:
 
 The release includes the following bug:
 
-- CMake might incorrectly set the API version (``BUILD_VERSION``) for an 
+- CMake might incorrectly set the API version for an 
   auto-downloaded C driver to ``0.0.0`` when the CMake project is configured 
   more than once or to the same value as the C++ driver's 
   API version when ``BUILD_VERSION`` is explicitly set during initial configuration. 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -45,7 +45,7 @@ The v4.0 driver release includes the following new features:
 The release includes the following bug:
 
 - CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
-  auto-downloaded C driver to 0.0.0 or to the same value as the C++'s Drivers 
+  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ Driver's 
   API version. CMake will only auto-download the C Driver with the C++ Driver 
   if it cannot find an existing C Driver installation. This will be fixed in 
   an upcoming patch release. 
@@ -76,7 +76,7 @@ The v3.11 driver release includes the following new features:
 The release includes the following bug:
 
 - CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
-  auto-downloaded C driver to 0.0.0 or to the same value as the C++'s Drivers 
+  auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ Driver's 
   API version. CMake will only auto-download the C Driver with the C++ Driver 
   if it cannot find an existing C Driver installation. This will be fixed in 
   an upcoming patch release. 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -47,8 +47,8 @@ The release includes the following bug:
 - CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
   auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ Driver's 
   API version. CMake will only auto-download the C Driver with the C++ Driver 
-  if it cannot find an existing C Driver installation. This will be fixed in 
-  an upcoming patch release. 
+  if it cannot find an existing C Driver installation. This ``BUILD_VERSION`` 
+  error will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the
 `v4.0 Release Notes <https://github.com/mongodb/mongo-cxx-driver/releases/tag/r4.0.0>`__
@@ -78,8 +78,8 @@ The release includes the following bug:
 - CMake may incorrectly set the API version (``BUILD_VERSION``) for an 
   auto-downloaded C driver to ``0.0.0`` or to the same value as the C++ Driver's 
   API version. CMake will only auto-download the C Driver with the C++ Driver 
-  if it cannot find an existing C Driver installation. This will be fixed in 
-  an upcoming patch release. 
+  if it cannot find an existing C Driver installation. This ``BUILD_VERSION`` 
+  error will be fixed in an upcoming patch release. 
 
 To learn more about this release, see the
 `v3.11 Release Notes <https://github.com/mongodb/mongo-cxx-driver/releases/tag/r3.11.0>`__


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-49002>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-124--docs-cpp.netlify.app/whats-new>whats-new</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [x] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?