### PR TITLE
Backport 135 to v4.1

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -135,6 +135,12 @@ The v4.1 driver introduces the following breaking changes to the build system:
 
 - Requires MongoDB C Driver v2.0.0 or later
 
+.. _version-4.1-enable-tests-config:
+
+- Sets the ``ENABLE_TESTS`` configuration option to ``OFF`` by default for
+  auto-downloaded versions of the C driver. :ref:`This is an expansion of the
+  change made in v4.0. <version-4.0-enable-tests-config>`
+
 ABI Breaking Changes in v4.1
 ````````````````````````````
 The v4.1 driver introduces the following breaking changes to the ABI:
@@ -145,7 +151,8 @@ The v4.1 driver introduces the following breaking changes to the ABI:
 
   .. note::
 
-     This does not affect users who compile with C++17 or newer and have not set ``BSONCXX_POLY_USE_IMPLS=ON``
+     This does not affect users who compile with C++17 or newer and have not set
+     ``BSONCXX_POLY_USE_IMPLS=ON``
 
 .. _version-4.0-breaking-changes:
 
@@ -170,10 +177,18 @@ The v4.0 driver introduces the following breaking changes to the build system:
 - Drops support for the ``MONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX`` configuration
   option. Default CMake behavior for ``CMAKE_INSTALL_PREFIX`` is now respected.
 
+.. _version-4.0-enable-tests-config:
+
 - Sets the ``ENABLE_TESTS`` configuration option to ``OFF`` by default. To
   re-enable building test targets, you must set ``ENABLE_TESTS`` to ``ON``.
   To include test targets in the "all" target, you must also set the
   ``BUILD_TESTING`` option to ``ON``.
+
+  .. note:: 
+
+    This change does not apply to auto-downloaded versions of the
+    C driver. :ref:`The change for auto-downloaded versions was added in
+    v4.1. <version-4.1-enable-tests-config>` 
 
 .. _version-4.0-api-breaking:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -50,6 +50,9 @@ The v4.1 driver release includes the following new features:
   - :manual:`Binary Data BSON Types </reference/bson-types/#binary-data>` in the {+mdb-server+} manual
   - :github:`BSON Binary Vector </mongodb/mongo-cxx-driver/blob/master/examples/bsoncxx/bson_binary_vector.cpp>` usage example on GitHub
 - Fixes the :ref:`C driver API version bug <v4.0-cmake-api-version-bug>` noted in the v4.0 release
+- Adds a change to the ``ENABLE_TESTS`` configuration default option that
+  was originally announced for v4.0. For more information, see the :ref:`breaking
+  change description <version-4.1-enable-tests-config>` on the Upgrade page.
 
 To learn more about this release, see the
 `v4.1 Release Notes <https://github.com/mongodb/mongo-cxx-driver/releases/tag/r4.1.0>`__


### PR DESCRIPTION
Backporting https://github.com/mongodb/docs-cpp/pull/135 to v4.1