### PR TITLE
[C++] Add monorepo notification 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-The source for the C++ Driver has been moved to the monorepo:
+The source for the C++ Driver has been moved to the docs-mongodb-internal repo:
 https://github.com/10gen/docs-mongodb-internal/tree/main/content/cpp-driver
 
 This repo is being maintained for archival reasons only.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-The source for the C++ Driver has been moved to the docs-mongodb-internal repo:
+The source for the C++ Driver documentation has been moved to the docs-mongodb-internal repo:
 https://github.com/10gen/docs-mongodb-internal/tree/main/content/cpp-driver
 
 This repo is being maintained for archival reasons only.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The source for the C++ Driver has been moved to the monorepo:
+The source for the C++ Driver has been moved to the docs-mongodb-internal repo:
 https://github.com/10gen/docs-mongodb-internal/tree/main/content/cpp-driver
 
 This repo is being maintained for archival reasons only.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The source for the C++ Driver has been moved to the docs-mongodb-internal repo:
+The source for the C++ Driver documentation has been moved to the docs-mongodb-internal repo:
 https://github.com/10gen/docs-mongodb-internal/tree/main/content/cpp-driver
 
 This repo is being maintained for archival reasons only.


### PR DESCRIPTION
The source for the C++ Driver has been moved to the monorepo:
https://github.com/10gen/docs-mongodb-internal/tree/main/content/cpp-driver

This repo is being maintained for archival reasons only.